### PR TITLE
Fix typo in older README files

### DIFF
--- a/README_old.md
+++ b/README_old.md
@@ -1,6 +1,6 @@
 # STPP Glue Code
 
-This repository provides a **glue code** framework for experimenting with Spatiotemporal Point Process (STPP) methods, at the momemnt only two frameworks are included: **NeuralSTPP** and **DeepSTPP** (with deepstpp not tested yet). It centralizes data loading, configuration, and training/evaluation scripts so you can easily switch or combine these methods.
+This repository provides a **glue code** framework for experimenting with Spatiotemporal Point Process (STPP) methods, at the moment only two frameworks are included: **NeuralSTPP** and **DeepSTPP** (with deepstpp not tested yet). It centralizes data loading, configuration, and training/evaluation scripts so you can easily switch or combine these methods.
 
 ## Contents
 

--- a/archive/README_OLD.md
+++ b/archive/README_OLD.md
@@ -1,6 +1,6 @@
 # STPP Glue Code
 
-This repository provides a **glue code** framework for experimenting with Spatiotemporal Point Process (STPP) methods, at the momemnt only two frameworks are included: **NeuralSTPP** and **DeepSTPP** (with deepstpp not tested yet). It centralizes data loading, configuration, and training/evaluation scripts so you can easily switch or combine these methods.
+This repository provides a **glue code** framework for experimenting with Spatiotemporal Point Process (STPP) methods, at the moment only two frameworks are included: **NeuralSTPP** and **DeepSTPP** (with deepstpp not tested yet). It centralizes data loading, configuration, and training/evaluation scripts so you can easily switch or combine these methods.
 
 ## Contents
 


### PR DESCRIPTION
## Summary
- fix typo `momemnt` → `moment` in README_old.md and archive/README_OLD.md

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'lightning')*