### PR TITLE
Docs revamp, dataset short names, and benchmark hub

### DIFF
--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -754,3 +754,213 @@
   .sh-home-arrow,
   .sh-home-card:hover .sh-home-arrow { transition: none; transform: none; }
 }
+
+/* ================================================================== *
+ * Extend Seahorse — the "bring your model" hub
+ * ================================================================== */
+
+/* --- the contract diagram: UnifiedSTPP(StateModel, EventModel) --- */
+.sh-ext-contract {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.55rem;
+  margin: 1.5rem 0;
+  padding: 1.4rem 1.3rem 1.3rem;
+  border: 1px solid var(--seahorse-border);
+  border-radius: 0.85rem;
+  background:
+    radial-gradient(150% 120% at 50% -10%, rgba(56, 166, 217, 0.1), transparent 55%),
+    linear-gradient(180deg, rgba(17, 24, 39, 0.92), rgba(15, 23, 42, 0.7));
+}
+.sh-ext-wrap {
+  align-self: flex-start;
+  font-family: var(--md-code-font-family, "Roboto Mono", monospace);
+  font-size: 0.66rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--md-default-fg-color--lighter);
+}
+.sh-ext-boxes {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: stretch;
+  gap: 0.65rem;
+  width: 100%;
+}
+.sh-ext-mod {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.95rem 1.05rem;
+  border: 1px solid var(--seahorse-border);
+  border-radius: 0.6rem;
+  background: rgba(15, 23, 42, 0.5);
+}
+.sh-ext-mod--state { border-top: 2px solid #38a6d9; }
+.sh-ext-mod--event { border-top: 2px solid #2dd4bf; }
+.sh-ext-mod-name { font-weight: 700; font-size: 1.02rem; }
+.sh-ext-mod--state .sh-ext-mod-name { color: #7fd3f0; }
+.sh-ext-mod--event .sh-ext-mod-name { color: #7ff0e0; }
+.sh-ext-mod-flow { font-size: 0.82rem; color: var(--md-default-fg-color--light); }
+.sh-ext-mod-api { display: flex; flex-wrap: wrap; gap: 0.3rem; margin-top: 0.15rem; }
+.md-typeset .sh-ext-mod-api code {
+  font-size: 0.66rem;
+  color: #cbd5e1;
+  background: rgba(148, 163, 184, 0.12);
+  border: none;
+  border-radius: 0.25rem;
+  padding: 0.05rem 0.35rem;
+}
+.sh-ext-join {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.35rem;
+  color: var(--seahorse-accent-hover);
+}
+.sh-ext-down { color: var(--md-default-fg-color--lighter); font-size: 0.85rem; }
+.sh-ext-out {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  width: 100%;
+  padding: 0.7rem 0.9rem;
+  border: 1px dashed rgba(56, 166, 217, 0.4);
+  border-radius: 0.6rem;
+  background: var(--seahorse-accent-soft);
+}
+.sh-ext-out-k {
+  font-family: var(--md-code-font-family, "Roboto Mono", monospace);
+  font-size: 0.6rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--md-default-fg-color--lighter);
+  margin-right: 0.25rem;
+}
+.sh-ext-pill {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: #bae6fd;
+  background: rgba(56, 166, 217, 0.14);
+  border: 1px solid rgba(56, 166, 217, 0.3);
+  padding: 0.12rem 0.5rem;
+  border-radius: 999px;
+}
+@media screen and (max-width: 44.9em) {
+  .sh-ext-boxes { grid-template-columns: 1fr; }
+  .sh-ext-join { transform: rotate(90deg); }
+}
+
+/* --- the four-step flow (a real ordered sequence) --- */
+.md-typeset .sh-ext-steps {
+  list-style: none;
+  margin: 1.2rem 0;
+  padding: 0;
+}
+.sh-ext-step {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.95rem;
+  padding-bottom: 1.15rem;
+}
+.sh-ext-step:not(:last-child)::before {
+  content: "";
+  position: absolute;
+  left: 0.95rem;
+  top: 2.1rem;
+  bottom: 0;
+  width: 1px;
+  background: var(--seahorse-border);
+}
+.sh-ext-num {
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.9rem;
+  height: 1.9rem;
+  border-radius: 999px;
+  font-family: var(--md-code-font-family, "Roboto Mono", monospace);
+  font-weight: 700;
+  font-size: 0.85rem;
+  color: #bae6fd;
+  background: var(--seahorse-accent-soft);
+  border: 1px solid rgba(56, 166, 217, 0.4);
+}
+.sh-ext-step-body { display: flex; flex-direction: column; gap: 0.45rem; padding-top: 0.1rem; min-width: 0; }
+.sh-ext-step-title { font-weight: 680; font-size: 1.04rem; color: #f8fafc; }
+.md-typeset .sh-ext-step-body p {
+  margin: 0;
+  font-size: 0.86rem;
+  line-height: 1.55;
+  color: var(--md-default-fg-color--light);
+}
+.sh-ext-code {
+  display: block;
+  font-family: var(--md-code-font-family, "Roboto Mono", monospace);
+  font-size: 0.72rem;
+  color: #9fe0ff;
+  background: #0b1220;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 0.4rem;
+  padding: 0.5rem 0.7rem;
+  overflow-x: auto;
+  white-space: pre;
+}
+.sh-ext-more { font-size: 0.82rem; font-weight: 600; color: var(--seahorse-accent-hover); text-decoration: none; }
+.sh-ext-more:hover { text-decoration: underline; }
+
+/* --- scenario path cards --- */
+.sh-ext-paths {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 0.85rem;
+  margin: 0.6rem 0 0.4rem;
+}
+.sh-ext-path {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 1rem 1.15rem;
+  border: 1px solid var(--seahorse-border);
+  border-radius: 0.6rem;
+  background: var(--md-default-bg-color--light, #141b26);
+  text-decoration: none;
+  color: var(--md-default-fg-color);
+  transition: transform 0.16s ease, border-color 0.16s ease, box-shadow 0.16s ease;
+}
+.sh-ext-path:hover {
+  transform: translateY(-3px);
+  border-color: var(--seahorse-accent-hover);
+  box-shadow: 0 10px 24px -16px rgba(2, 132, 199, 0.7);
+}
+.sh-ext-path-when {
+  font-family: var(--md-code-font-family, "Roboto Mono", monospace);
+  font-size: 0.63rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #38a6d9;
+}
+.sh-ext-path-title { font-weight: 680; font-size: 1.02rem; color: #f8fafc; padding-right: 1rem; }
+.sh-ext-path-desc { font-size: 0.82rem; line-height: 1.5; color: var(--md-default-fg-color--light); }
+.sh-ext-path-go {
+  position: absolute;
+  top: 0.95rem;
+  right: 1rem;
+  color: var(--md-default-fg-color--lighter);
+  transition: transform 0.16s ease, color 0.16s ease;
+}
+.sh-ext-path:hover .sh-ext-path-go { color: var(--seahorse-accent-hover); transform: translateX(3px); }
+
+@media (prefers-reduced-motion: reduce) {
+  .sh-ext-path,
+  .sh-ext-path:hover,
+  .sh-ext-path-go,
+  .sh-ext-path:hover .sh-ext-path-go { transition: none; transform: none; }
+}

--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -1103,3 +1103,104 @@
   background: rgba(148, 163, 184, 0.12);
   border: none;
 }
+
+/* ================================================================== *
+ * Declare Capabilities — method → unlocks cards + comparability tiers
+ * ================================================================== */
+
+.sh-cap-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 0.85rem;
+  margin: 1.1rem 0;
+}
+.sh-cap {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  padding: 1rem 1.1rem;
+  border: 1px solid var(--seahorse-border);
+  border-left: 2px solid var(--seahorse-border);
+  border-radius: 0.6rem;
+  background: var(--md-default-bg-color--light, #141b26);
+}
+.sh-cap--exact { border-left-color: #38a6d9; }
+.sh-cap--approx { border-left-color: #f5b971; }
+.sh-cap--optional { border-left-color: #2dd4bf; }
+.sh-cap--auto { border-left-color: #94a3b8; }
+.sh-cap-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+.sh-cap-name { font-weight: 700; font-size: 1rem; color: #f8fafc; }
+.sh-cap-tag {
+  flex: none;
+  font-family: var(--md-code-font-family, "Roboto Mono", monospace);
+  font-size: 0.57rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.14);
+  color: #cbd5e1;
+}
+.sh-cap--exact .sh-cap-tag { background: rgba(56, 166, 217, 0.16); color: #7dd3fc; }
+.sh-cap--approx .sh-cap-tag { background: rgba(245, 185, 113, 0.16); color: #f5cf9b; }
+.sh-cap--optional .sh-cap-tag { background: rgba(45, 212, 191, 0.16); color: #5eead4; }
+.sh-cap-by { font-size: 0.8rem; line-height: 1.5; color: var(--md-default-fg-color--light); }
+.md-typeset .sh-cap-by code { font-size: 0.72rem; }
+.sh-cap-unlocks {
+  font-family: var(--md-code-font-family, "Roboto Mono", monospace);
+  font-size: 0.57rem;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+  color: var(--md-default-fg-color--lighter);
+  margin-top: 0.05rem;
+}
+.sh-cap-chips { display: flex; flex-wrap: wrap; gap: 0.3rem; }
+.sh-cap-chip {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #bae6fd;
+  background: rgba(56, 166, 217, 0.12);
+  border: 1px solid rgba(56, 166, 217, 0.28);
+  padding: 0.1rem 0.45rem;
+  border-radius: 0.3rem;
+}
+
+/* exact vs approximate comparability tiers */
+.sh-tier { display: flex; flex-direction: column; gap: 0.7rem; margin: 1.1rem 0; }
+.sh-tier-row {
+  display: grid;
+  grid-template-columns: minmax(140px, 180px) 1fr;
+  gap: 0.9rem;
+  align-items: center;
+  padding: 0.9rem 1rem;
+  border: 1px solid var(--seahorse-border);
+  border-left: 3px solid var(--seahorse-border);
+  border-radius: 0.6rem;
+  background: var(--md-default-bg-color--light, #141b26);
+}
+.sh-tier-row--exact { border-left-color: #38a6d9; }
+.sh-tier-row--approx { border-left-color: #f5b971; }
+.sh-tier-label { display: flex; flex-direction: column; gap: 0.1rem; }
+.sh-tier-name { font-weight: 700; font-size: 0.95rem; }
+.sh-tier-row--exact .sh-tier-name { color: #7fd3f0; }
+.sh-tier-row--approx .sh-tier-name { color: #f5cf9b; }
+.sh-tier-sub { font-size: 0.72rem; color: var(--md-default-fg-color--lighter); }
+.sh-tier-chips { display: flex; flex-wrap: wrap; gap: 0.35rem; }
+.sh-fam {
+  font-family: var(--md-code-font-family, "Roboto Mono", monospace);
+  font-size: 0.72rem;
+  color: #cbd5e1;
+  background: rgba(148, 163, 184, 0.12);
+  border: 1px solid var(--seahorse-border);
+  border-radius: 0.3rem;
+  padding: 0.1rem 0.45rem;
+}
+.sh-fam em { color: var(--md-default-fg-color--lighter); font-style: normal; font-size: 0.66rem; }
+@media screen and (max-width: 44.9em) {
+  .sh-tier-row { grid-template-columns: 1fr; }
+}

--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -964,3 +964,142 @@
   .sh-ext-path-go,
   .sh-ext-path:hover .sh-ext-path-go { transition: none; transform: none; }
 }
+
+/* ================================================================== *
+ * Wrap a model — data-flow anatomy + component responsibilities
+ * ================================================================== */
+
+/* --- vertical data-flow diagram (shapes transforming through methods) --- */
+.sh-flow {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 1.4rem 0;
+}
+.sh-flow-node {
+  width: 100%;
+  max-width: 32rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.2rem;
+  padding: 0.7rem 1rem;
+  text-align: center;
+  border: 1px solid var(--seahorse-border);
+  border-radius: 0.6rem;
+  background: rgba(15, 23, 42, 0.5);
+}
+.sh-flow-node--io {
+  background: var(--seahorse-accent-soft);
+  border-color: rgba(56, 166, 217, 0.3);
+}
+.sh-flow-shape {
+  font-family: var(--md-code-font-family, "Roboto Mono", monospace);
+  font-size: 0.74rem;
+  color: #9fe0ff;
+}
+.sh-flow-node--io .sh-flow-shape { color: #bae6fd; font-weight: 600; }
+.sh-flow-note { font-size: 0.74rem; color: var(--md-default-fg-color--light); }
+.sh-flow-edge {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 2.7rem;
+}
+.sh-flow-edge::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 1px;
+  background: var(--seahorse-border);
+  transform: translateX(-50%);
+}
+.sh-flow-edge::after {
+  content: "";
+  position: absolute;
+  bottom: -1px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 5px solid var(--seahorse-border);
+}
+.sh-flow-call {
+  position: relative;
+  z-index: 1;
+  font-family: var(--md-code-font-family, "Roboto Mono", monospace);
+  font-size: 0.68rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: #0b1220;
+  border: 1px solid var(--seahorse-border);
+  color: #cbd5e1;
+}
+.sh-flow-edge--state .sh-flow-call { border-color: rgba(56, 166, 217, 0.5); color: #7fd3f0; }
+.sh-flow-edge--event .sh-flow-call { border-color: rgba(45, 212, 191, 0.5); color: #7ff0e0; }
+
+/* --- component responsibility cards (what owns what) --- */
+.sh-comp-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 0.85rem;
+  margin: 1.1rem 0;
+}
+.sh-comp {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem 1.1rem;
+  border: 1px solid var(--seahorse-border);
+  border-top: 2px solid var(--seahorse-border);
+  border-radius: 0.6rem;
+  background: var(--md-default-bg-color--light, #141b26);
+}
+.sh-comp--state { border-top-color: #38a6d9; }
+.sh-comp--event { border-top-color: #2dd4bf; }
+.sh-comp--descriptor { border-top-color: #f5b971; }
+.sh-comp-tag {
+  align-self: flex-start;
+  font-family: var(--md-code-font-family, "Roboto Mono", monospace);
+  font-size: 0.58rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  background: rgba(56, 166, 217, 0.14);
+  color: #7dd3fc;
+}
+.sh-comp-tag--opt { background: rgba(245, 185, 113, 0.16); color: #f5cf9b; }
+.sh-comp-name { font-weight: 700; font-size: 1.02rem; color: #f8fafc; }
+.sh-comp--state .sh-comp-name { color: #7fd3f0; }
+.sh-comp--event .sh-comp-name { color: #7ff0e0; }
+.sh-comp--descriptor .sh-comp-name { color: #f5cf9b; }
+.sh-comp-role { font-size: 0.82rem; line-height: 1.5; color: var(--md-default-fg-color--light); }
+.sh-comp-methods { display: flex; flex-direction: column; gap: 0.4rem; margin-top: 0.1rem; }
+.sh-comp-m { display: flex; flex-direction: column; gap: 0.12rem; }
+.md-typeset .sh-comp-m code {
+  align-self: flex-start;
+  font-size: 0.7rem;
+  color: #bae6fd;
+  background: rgba(56, 166, 217, 0.1);
+  border: none;
+  border-radius: 0.25rem;
+  padding: 0.08rem 0.4rem;
+}
+.sh-comp-m span { font-size: 0.69rem; color: var(--md-default-fg-color--lighter); }
+.sh-comp-where {
+  margin-top: auto;
+  padding-top: 0.45rem;
+  border-top: 1px dashed var(--seahorse-border);
+  font-size: 0.72rem;
+  color: var(--md-default-fg-color--lighter);
+}
+.md-typeset .sh-comp-where code {
+  font-size: 0.68rem;
+  background: rgba(148, 163, 184, 0.12);
+  border: none;
+}

--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -54,6 +54,27 @@
   }
 }
 
+/* Readability: hold running text to a comfortable reading measure on wide
+   screens, while cards, tables, code, diagrams, and figures keep the full
+   canvas. Classed blocks (cards, eyebrows, hero) opt out and stay full width. */
+.md-content__inner.md-typeset > p:not([class]),
+.md-content__inner.md-typeset > ul:not([class]),
+.md-content__inner.md-typeset > ol:not([class]),
+.md-content__inner.md-typeset > blockquote,
+.md-content__inner.md-typeset > .admonition,
+.md-content__inner.md-typeset > h1:not([class]),
+.md-content__inner.md-typeset > h2,
+.md-content__inner.md-typeset > h3,
+.md-content__inner.md-typeset > h4 {
+  max-width: 32rem;
+}
+/* code and tabbed code share the reading column (a touch wider for long lines) */
+.md-content__inner.md-typeset > .highlight,
+.md-content__inner.md-typeset > pre,
+.md-content__inner.md-typeset > .tabbed-set {
+  max-width: 36rem;
+}
+
 .md-main__inner {
   margin-top: 1.2rem;
 }

--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -1204,3 +1204,164 @@
 @media screen and (max-width: 44.9em) {
   .sh-tier-row { grid-template-columns: 1fr; }
 }
+
+/* ================================================================== *
+ * Register hub — one name, reachable everywhere
+ * ================================================================== */
+.sh-hub {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0;
+  margin: 1.5rem 0;
+  padding: 1.4rem 1.3rem 1.2rem;
+  border: 1px solid var(--seahorse-border);
+  border-radius: 0.85rem;
+  background:
+    radial-gradient(150% 130% at 50% -10%, rgba(56, 166, 217, 0.1), transparent 55%),
+    linear-gradient(180deg, rgba(17, 24, 39, 0.92), rgba(15, 23, 42, 0.7));
+  text-align: center;
+}
+.sh-hub-center { display: flex; flex-direction: column; align-items: center; gap: 0.4rem; }
+.sh-hub-k {
+  font-family: var(--md-code-font-family, "Roboto Mono", monospace);
+  font-size: 0.6rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--md-default-fg-color--lighter);
+}
+.md-typeset .sh-hub-token {
+  font-size: 0.82rem;
+  color: #bae6fd;
+  background: var(--seahorse-accent-soft);
+  border: 1px solid rgba(56, 166, 217, 0.4);
+  border-radius: 0.4rem;
+  padding: 0.3rem 0.7rem;
+}
+.sh-hub-fan {
+  width: 1px;
+  height: 1.5rem;
+  background: linear-gradient(180deg, rgba(56, 166, 217, 0.6), var(--seahorse-border));
+}
+.sh-hub-spokes {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.45rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--seahorse-border);
+  width: 100%;
+}
+.sh-hub-spoke {
+  font-family: var(--md-code-font-family, "Roboto Mono", monospace);
+  font-size: 0.74rem;
+  color: #cbd5e1;
+  background: rgba(56, 166, 217, 0.1);
+  border: 1px solid rgba(56, 166, 217, 0.28);
+  border-radius: 0.35rem;
+  padding: 0.2rem 0.55rem;
+}
+.sh-hub-cap {
+  margin-top: 0.9rem;
+  max-width: 38rem;
+  font-size: 0.8rem;
+  line-height: 1.55;
+  color: var(--md-default-fg-color--light);
+}
+
+/* ================================================================== *
+ * Quickstart stage labels (numbered code stages)
+ * ================================================================== */
+.sh-stage-label {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  margin: 1.3rem 0 0.5rem;
+  font-weight: 680;
+  font-size: 1rem;
+  color: #f8fafc;
+}
+.sh-stage-num {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 999px;
+  font-family: var(--md-code-font-family, "Roboto Mono", monospace);
+  font-weight: 700;
+  font-size: 0.78rem;
+  color: #bae6fd;
+  background: var(--seahorse-accent-soft);
+  border: 1px solid rgba(56, 166, 217, 0.4);
+}
+
+/* ================================================================== *
+ * Colab call-to-action (case study)
+ * ================================================================== */
+.sh-colab-cta {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  margin: 1.3rem 0;
+  padding: 0.95rem 1.2rem;
+  border: 1px solid var(--seahorse-border);
+  border-left: 3px solid #f9ab00; /* Colab amber */
+  border-radius: 0.7rem;
+  background:
+    radial-gradient(120% 140% at 0% 0%, rgba(249, 171, 0, 0.1), transparent 55%),
+    linear-gradient(180deg, rgba(17, 24, 39, 0.9), rgba(15, 23, 42, 0.72));
+  text-decoration: none;
+  color: var(--md-default-fg-color);
+  transition: transform 0.16s ease, border-color 0.16s ease, box-shadow 0.16s ease;
+}
+.sh-colab-cta:hover {
+  transform: translateY(-2px);
+  border-color: #f9ab00;
+  box-shadow: 0 14px 30px -20px rgba(249, 171, 0, 0.8);
+}
+.sh-colab-badge {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.3rem;
+  height: 2.3rem;
+  border-radius: 0.55rem;
+  background: rgba(249, 171, 0, 0.16);
+  border: 1px solid rgba(249, 171, 0, 0.4);
+  color: #ffc94d;
+  font-size: 0.95rem;
+}
+.sh-colab-text { display: flex; flex-direction: column; gap: 0.1rem; flex: 1 1 auto; }
+.sh-colab-text strong { font-size: 0.98rem; color: #f8fafc; }
+.sh-colab-text span { font-size: 0.76rem; color: var(--md-default-fg-color--light); }
+.sh-colab-go { flex: none; color: var(--md-default-fg-color--lighter); transition: transform 0.16s ease, color 0.16s ease; }
+.sh-colab-cta:hover .sh-colab-go { color: #ffc94d; transform: translate(2px, -2px); }
+
+/* ================================================================== *
+ * Page feedback — distinct yes/no follow-ups
+ * ================================================================== */
+.sh-feedback__yes,
+.sh-feedback__no { display: none; }
+[data-sh-feedback="yes"] .sh-feedback__yes { display: inline; }
+[data-sh-feedback="no"] .sh-feedback__no { display: inline; }
+[data-sh-feedback="yes"] .sh-feedback__prompt,
+[data-sh-feedback="yes"] .sh-feedback__btn,
+[data-sh-feedback="no"] .sh-feedback__prompt,
+[data-sh-feedback="no"] .sh-feedback__btn { display: none; }
+.sh-feedback__yes a,
+.sh-feedback__no a {
+  color: var(--seahorse-accent-hover);
+  font-weight: 600;
+}
+[data-md-color-scheme="slate"] .sh-feedback__yes a,
+[data-md-color-scheme="slate"] .sh-feedback__no a { color: #7dd3fc; }
+
+@media (prefers-reduced-motion: reduce) {
+  .sh-colab-cta,
+  .sh-colab-cta:hover,
+  .sh-colab-go,
+  .sh-colab-cta:hover .sh-colab-go { transition: none; transform: none; }
+}

--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -488,13 +488,20 @@
   box-shadow: 0 10px 24px -16px rgba(2, 132, 199, 0.7);
 }
 
-/* core-benchmark and abstract cards carry a left accent rail */
+/* core-benchmark, abstract, and synthetic cards carry a left accent rail */
 .sh-ds-card--bench { border-left: 2px solid var(--seahorse-accent-hover); }
 .sh-ds-card--abstract { border-left: 2px solid #7c4dff; }
 .sh-ds-card--abstract:hover {
   border-color: #7c4dff;
   box-shadow: 0 10px 24px -16px rgba(124, 77, 255, 0.7);
 }
+.sh-ds-card--synth { border-left: 2px solid #2dd4bf; }
+.sh-ds-card--synth:hover {
+  border-color: #2dd4bf;
+  box-shadow: 0 10px 24px -16px rgba(45, 212, 191, 0.7);
+}
+/* a full-width card spans the whole grid row */
+.sh-ds-card--wide { grid-column: 1 / -1; }
 
 .sh-ds-head {
   display: flex;
@@ -527,6 +534,11 @@
   color: #c4b5fd;
   background: rgba(124, 77, 255, 0.16);
   border-color: rgba(124, 77, 255, 0.4);
+}
+.sh-ds-chip--synth {
+  color: #5eead4;
+  background: rgba(45, 212, 191, 0.14);
+  border-color: rgba(45, 212, 191, 0.4);
 }
 
 .sh-ds-id {
@@ -594,4 +606,23 @@
   .sh-ds-card:hover,
   .sh-ds-go,
   .sh-ds-card:hover .sh-ds-go { transition: none; transform: none; }
+}
+
+/* ------------------------------------------------------------------ *
+ * Homepage hero action cards
+ * Material puts display:grid on the .grid div (auto-fit) and makes the
+ * inner <ul> display:contents, so its <li> cards are the grid items.
+ * The default auto-fit lays the four cards out 3-then-1; override the
+ * column track on the div to force a balanced 2x2 (one column on phones).
+ * ------------------------------------------------------------------ */
+
+.md-typeset .grid.cards.hero-cards {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.9rem;
+}
+
+@media screen and (max-width: 44.9em) {
+  .md-typeset .grid.cards.hero-cards {
+    grid-template-columns: 1fr;
+  }
 }

--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -1386,3 +1386,126 @@
   .sh-colab-go,
   .sh-colab-cta:hover .sh-colab-go { transition: none; transform: none; }
 }
+
+/* ================================================================== *
+ * Benchmark overview — the payoff: your model meets the field, fairly
+ * Signature: the campaign matrix. Rows are presets, columns are the
+ * core-trio datasets, and every cell is one (preset × dataset × seed)
+ * run executed under the same contract. The left rail encodes the NLL
+ * class (exact / bound); your model slots in as a glowing row.
+ * ================================================================== */
+
+.sh-bench-board {
+  margin: 1.4rem 0 0.5rem;
+  padding: 1.25rem 1.4rem 1.15rem;
+  border: 1px solid var(--seahorse-border);
+  border-radius: 0.85rem;
+  background:
+    radial-gradient(150% 130% at 50% -10%, rgba(56, 166, 217, 0.1), transparent 55%),
+    linear-gradient(180deg, rgba(17, 24, 39, 0.92), rgba(15, 23, 42, 0.7));
+  overflow-x: auto;
+}
+.sh-bench-matrix {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  min-width: 28rem;
+}
+.sh-bench-row {
+  display: grid;
+  grid-template-columns: minmax(9rem, 1.5fr) repeat(3, 1fr);
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.36rem 0.6rem 0.36rem 0.7rem;
+  border-left: 2px solid transparent;
+  border-radius: 0.4rem;
+}
+.sh-bench-row--head {
+  padding-top: 0;
+  padding-bottom: 0.45rem;
+  margin-bottom: 0.1rem;
+  border-left-color: transparent;
+  border-bottom: 1px solid var(--seahorse-border);
+  border-radius: 0;
+}
+.sh-bench-row--exact { border-left-color: rgba(56, 166, 217, 0.55); }
+.sh-bench-row--bound,
+.sh-bench-row--approx { border-left-color: #f5b971; }
+.sh-bench-row--you {
+  border-left-color: var(--seahorse-accent-hover);
+  background: rgba(56, 166, 217, 0.1);
+}
+
+.sh-bench-model {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-width: 0;
+  font-family: var(--md-code-font-family, "Roboto Mono", monospace);
+  font-size: 0.74rem;
+  color: #cbd5e1;
+  overflow-wrap: anywhere;
+}
+.sh-bench-row--you .sh-bench-model { color: #bae6fd; font-weight: 600; }
+.sh-bench-model--head {
+  font-size: 0.58rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--md-default-fg-color--lighter);
+}
+.sh-bench-col {
+  font-family: var(--md-code-font-family, "Roboto Mono", monospace);
+  font-size: 0.58rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  text-align: center;
+  color: var(--md-default-fg-color--lighter);
+}
+.sh-bench-cell { display: flex; align-items: center; justify-content: center; }
+.sh-bench-dot {
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 50%;
+  background: rgba(148, 163, 184, 0.5);
+}
+.sh-bench-row--you .sh-bench-dot {
+  background: #38a6d9;
+  box-shadow: 0 0 0 3px rgba(56, 166, 217, 0.2);
+}
+.sh-bench-newchip {
+  flex: none;
+  font-size: 0.52rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #7dd3fc;
+  background: var(--seahorse-accent-soft);
+  border: 1px solid rgba(56, 166, 217, 0.4);
+  padding: 0.05rem 0.34rem;
+  border-radius: 999px;
+}
+
+.sh-bench-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 1.2rem;
+  margin-top: 0.95rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--seahorse-border);
+  font-size: 0.71rem;
+  color: var(--md-default-fg-color--light);
+}
+.sh-bench-legend > span { display: inline-flex; align-items: center; gap: 0.45rem; }
+.sh-bench-rail { width: 0.2rem; height: 0.85rem; border-radius: 1px; flex: none; }
+.sh-bench-rail--exact { background: rgba(56, 166, 217, 0.8); }
+.sh-bench-rail--bound { background: #f5b971; }
+.sh-bench-keydot {
+  width: 0.6rem; height: 0.6rem; border-radius: 50%; flex: none;
+  background: #38a6d9; box-shadow: 0 0 0 3px rgba(56, 166, 217, 0.2);
+}
+.sh-bench-cap {
+  max-width: 46rem;
+  margin: 0.45rem 0 0;
+  font-size: 0.74rem;
+  line-height: 1.55;
+  color: var(--md-default-fg-color--lighter);
+}

--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -645,19 +645,112 @@
 
 /* ------------------------------------------------------------------ *
  * Homepage hero action cards
- * Material puts display:grid on the .grid div (auto-fit) and makes the
- * inner <ul> display:contents, so its <li> cards are the grid items.
- * The default auto-fit lays the four cards out 3-then-1; override the
- * column track on the div to force a balanced 2x2 (one column on phones).
+ * Same DNA as the dataset cards (dark panel, mono "handle", corner arrow)
+ * dialed up for the front door: icon badges, an accent radial glow, a
+ * hover sheen line, and a gradient-railed primary card. Fixed 2x2.
  * ------------------------------------------------------------------ */
 
-.md-typeset .grid.cards.hero-cards {
+.md-typeset .sh-home-grid {
+  display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.9rem;
+  gap: 1rem;
+  margin: 1.4rem 0 0.5rem;
+}
+@media screen and (max-width: 44.9em) {
+  .md-typeset .sh-home-grid { grid-template-columns: 1fr; }
 }
 
-@media screen and (max-width: 44.9em) {
-  .md-typeset .grid.cards.hero-cards {
-    grid-template-columns: 1fr;
-  }
+.sh-home-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  padding: 1.25rem 1.35rem 1.15rem;
+  border: 1px solid var(--seahorse-border);
+  border-radius: 0.7rem;
+  background:
+    radial-gradient(120% 120% at 100% 0%, rgba(56, 166, 217, 0.08), transparent 45%),
+    linear-gradient(180deg, rgba(17, 24, 39, 0.9), rgba(15, 23, 42, 0.72));
+  color: var(--md-default-fg-color);
+  text-decoration: none;
+  overflow: hidden;
+  transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
+}
+/* a thin accent sheen along the top edge, revealed on hover */
+.sh-home-card::after {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(56, 166, 217, 0.55), transparent);
+  opacity: 0;
+  transition: opacity 0.18s ease;
+}
+.sh-home-card:hover {
+  transform: translateY(-4px);
+  border-color: var(--seahorse-accent-hover);
+  box-shadow: 0 18px 40px -24px rgba(2, 132, 199, 0.8);
+}
+.sh-home-card:hover::after { opacity: 1; }
+
+/* primary card: stronger glow + gradient rail */
+.sh-home-card--primary {
+  border-left: 2px solid var(--seahorse-accent-hover);
+  background:
+    radial-gradient(130% 130% at 100% 0%, rgba(56, 166, 217, 0.16), transparent 50%),
+    linear-gradient(180deg, rgba(18, 30, 48, 0.95), rgba(15, 23, 42, 0.78));
+}
+
+.sh-home-top { display: flex; align-items: center; gap: 0.65rem; }
+.sh-home-icon {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.1rem;
+  height: 2.1rem;
+  border-radius: 0.55rem;
+  background: var(--seahorse-accent-soft);
+  border: 1px solid rgba(56, 166, 217, 0.3);
+}
+.sh-home-icon svg { width: 1.2rem; height: 1.2rem; fill: #58c4e8; }
+.sh-home-title { font-weight: 680; font-size: 1.12rem; color: #f8fafc; }
+
+.sh-home-handle {
+  align-self: flex-start;
+  max-width: 100%;
+  font-family: var(--md-code-font-family, "Roboto Mono", monospace);
+  font-size: 0.72rem;
+  color: #9fe0ff;
+  background: rgba(56, 166, 217, 0.1);
+  border: 1px solid rgba(56, 166, 217, 0.18);
+  padding: 0.18rem 0.5rem;
+  border-radius: 0.35rem;
+  overflow-wrap: anywhere;
+  box-shadow: none;
+}
+
+.sh-home-desc {
+  flex: 1 1 auto;
+  font-size: 0.88rem;
+  line-height: 1.55;
+  color: var(--md-default-fg-color--light);
+}
+
+.sh-home-foot {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--seahorse-accent-hover);
+}
+.sh-home-arrow { transition: transform 0.18s ease; }
+.sh-home-card:hover .sh-home-arrow { transform: translateX(4px); }
+
+@media (prefers-reduced-motion: reduce) {
+  .sh-home-card,
+  .sh-home-card:hover,
+  .sh-home-arrow,
+  .sh-home-card:hover .sh-home-arrow { transition: none; transform: none; }
 }

--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -463,8 +463,8 @@
 
 .sh-ds-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-  gap: 0.85rem;
+  grid-template-columns: repeat(auto-fill, minmax(290px, 1fr));
+  gap: 0.9rem;
   margin: 0 0 0.4rem;
 }
 
@@ -503,18 +503,52 @@
 /* a full-width card spans the whole grid row */
 .sh-ds-card--wide { grid-column: 1 / -1; }
 
+/* feature row: one card paired with an explanatory aside (Beyond the map) */
+.sh-ds-feature {
+  display: grid;
+  grid-template-columns: minmax(260px, 340px) 1fr;
+  gap: 0.9rem;
+  align-items: stretch;
+  margin: 0 0 0.4rem;
+}
+@media screen and (max-width: 44.9em) {
+  .sh-ds-feature { grid-template-columns: 1fr; }
+}
+.sh-ds-aside {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.55rem;
+  padding: 1.1rem 1.3rem;
+  border: 1px dashed rgba(124, 77, 255, 0.4);
+  border-radius: 0.55rem;
+  background: rgba(124, 77, 255, 0.05);
+}
+.sh-ds-aside-title {
+  font-weight: 650;
+  font-size: 0.92rem;
+  color: #d8c7ff;
+}
+.md-typeset .sh-ds-aside p {
+  margin: 0;
+  font-size: 0.86rem;
+  line-height: 1.6;
+  color: var(--md-default-fg-color--light);
+}
+
 .sh-ds-head {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-  padding-right: 1.1rem; /* clear the corner arrow */
+  flex-direction: column; /* title on its own line; chip sits beneath it */
+  align-items: flex-start;
+  gap: 0.45rem;
+  padding-right: 1.4rem; /* clear the corner arrow */
 }
 .sh-ds-name {
-  font-weight: 600;
-  font-size: 0.95rem;
-  line-height: 1.2;
+  font-weight: 650;
+  font-size: 1.05rem;
+  line-height: 1.25;
   color: #f8fafc;
+  overflow-wrap: anywhere; /* break gracefully, never one char per line */
 }
 
 .sh-ds-chip {
@@ -550,7 +584,8 @@
   background: rgba(56, 166, 217, 0.1);
   padding: 0.1rem 0.4rem;
   border-radius: 0.3rem;
-  word-break: break-all;
+  word-break: normal;
+  overflow-wrap: anywhere; /* prefer breaking at / - _ rather than mid-token */
   box-shadow: none;
 }
 

--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -446,3 +446,152 @@
   color: #7dd3fc;
 }
 
+
+/* ------------------------------------------------------------------ *
+ * Dataset catalog gallery (datasets/catalog.md)
+ * Events in space and time, ordered from city block to cortex.
+ * ------------------------------------------------------------------ */
+
+.sh-ds-eyebrow {
+  margin: -0.2rem 0 0.9rem;
+  font-family: var(--md-code-font-family, "Roboto Mono", monospace);
+  font-size: 0.66rem;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  color: var(--md-default-fg-color--lighter);
+}
+
+.sh-ds-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 0.85rem;
+  margin: 0 0 0.4rem;
+}
+
+.sh-ds-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.95rem 1.05rem 0.85rem;
+  border: 1px solid var(--seahorse-border);
+  border-radius: 0.55rem;
+  background: var(--md-default-bg-color--light, #141b26);
+  color: var(--md-default-fg-color);
+  text-decoration: none;
+  overflow: hidden;
+  transition: transform 0.16s ease, border-color 0.16s ease, box-shadow 0.16s ease;
+}
+.sh-ds-card:hover {
+  transform: translateY(-3px);
+  border-color: var(--seahorse-accent-hover);
+  box-shadow: 0 10px 24px -16px rgba(2, 132, 199, 0.7);
+}
+
+/* core-benchmark and abstract cards carry a left accent rail */
+.sh-ds-card--bench { border-left: 2px solid var(--seahorse-accent-hover); }
+.sh-ds-card--abstract { border-left: 2px solid #7c4dff; }
+.sh-ds-card--abstract:hover {
+  border-color: #7c4dff;
+  box-shadow: 0 10px 24px -16px rgba(124, 77, 255, 0.7);
+}
+
+.sh-ds-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding-right: 1.1rem; /* clear the corner arrow */
+}
+.sh-ds-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+  line-height: 1.2;
+  color: #f8fafc;
+}
+
+.sh-ds-chip {
+  flex: none;
+  font-family: var(--md-code-font-family, "Roboto Mono", monospace);
+  font-size: 0.58rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #7dd3fc;
+  background: var(--seahorse-accent-soft);
+  border: 1px solid rgba(56, 166, 217, 0.35);
+  padding: 0.12rem 0.42rem;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+.sh-ds-chip--muted {
+  color: #c4b5fd;
+  background: rgba(124, 77, 255, 0.16);
+  border-color: rgba(124, 77, 255, 0.4);
+}
+
+.sh-ds-id {
+  align-self: flex-start;
+  max-width: 100%;
+  font-family: var(--md-code-font-family, "Roboto Mono", monospace);
+  font-size: 0.7rem;
+  color: #7dd3fc;
+  background: rgba(56, 166, 217, 0.1);
+  padding: 0.1rem 0.4rem;
+  border-radius: 0.3rem;
+  word-break: break-all;
+  box-shadow: none;
+}
+
+.sh-ds-desc {
+  flex: 1 1 auto;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  color: var(--md-default-fg-color--light);
+}
+
+.sh-ds-axes {
+  display: grid;
+  gap: 0.18rem;
+  margin-top: 0.2rem;
+  padding-top: 0.6rem;
+  border-top: 1px dashed var(--seahorse-border);
+}
+.sh-ds-axis {
+  display: flex;
+  align-items: baseline;
+  gap: 0.55rem;
+  font-size: 0.74rem;
+  color: var(--md-default-fg-color--light);
+}
+.sh-ds-k {
+  flex: none;
+  width: 2.6rem;
+  font-family: var(--md-code-font-family, "Roboto Mono", monospace);
+  font-size: 0.62rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #38a6d9;
+}
+
+.sh-ds-go {
+  position: absolute;
+  top: 0.85rem;
+  right: 0.9rem;
+  font-size: 0.85rem;
+  line-height: 1;
+  color: var(--md-default-fg-color--lighter);
+  opacity: 0.6;
+  transition: transform 0.16s ease, opacity 0.16s ease, color 0.16s ease;
+}
+.sh-ds-card:hover .sh-ds-go {
+  opacity: 1;
+  color: var(--seahorse-accent-hover);
+  transform: translate(2px, -2px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sh-ds-card,
+  .sh-ds-card:hover,
+  .sh-ds-go,
+  .sh-ds-card:hover .sh-ds-go { transition: none; transform: none; }
+}

--- a/docs/benchmark/compare.md
+++ b/docs/benchmark/compare.md
@@ -2,6 +2,25 @@
 
 After running a benchmark you typically want to compare models by NLL, inspect predictive quality on specific sequences, and understand which families differ meaningfully.
 
+NLL is only comparable across presets that compute it the same way, so the tables separate two tiers:
+
+<div class="sh-tier" markdown="0">
+  <div class="sh-tier-row sh-tier-row--exact">
+    <div class="sh-tier-label"><span class="sh-tier-name">Exact</span><span class="sh-tier-sub">directly comparable</span></div>
+    <div class="sh-tier-chips">
+      <span class="sh-fam">auto_stpp</span><span class="sh-fam">deep_stpp</span><span class="sh-fam">nsmpp</span><span class="sh-fam">njsde</span><span class="sh-fam">neural_*</span><span class="sh-fam">poisson_*</span><span class="sh-fam">hawkes_*</span><span class="sh-fam">rmtpp_gmm</span><span class="sh-fam">thp_gmm</span>
+    </div>
+  </div>
+  <div class="sh-tier-row sh-tier-row--approx">
+    <div class="sh-tier-label"><span class="sh-tier-name">Approximate</span><span class="sh-tier-sub">a bound on the likelihood</span></div>
+    <div class="sh-tier-chips">
+      <span class="sh-fam">smash <em>· score-matching</em></span><span class="sh-fam">diffusion_stpp <em>· ELBO</em></span>
+    </div>
+  </div>
+</div>
+
+The `table_test_nll_exact.csv` table is already restricted to the exact tier, which is the natural starting point.
+
 ## Reading the Benchmark Tables
 
 `bench` writes summary tables to the campaign directory:
@@ -65,8 +84,7 @@ Then read `metrics.json` from each output directory to compare CRPS, energy scor
 ## Interpreting NLL Differences
 
 - NLL values are only directly comparable across presets that share the **same dataset, normalization policy, and metric definition** — which `bench` enforces via the [benchmark contract](../learn/execution-contract.md).
-- Exact-NLL families (`auto_stpp`, `deep_stpp`, `poisson_gmm`, ...) are comparable with each other.
-- Approximate families (`smash`, `diffusion_stpp`) optimize surrogate objectives; note this when including them in comparison tables.
+- Stay within a tier (above): exact families are read directly against each other; approximate families report a bound (score-matching or ELBO), so present them on those terms rather than ranking them against exact NLL.
 - See the [Model Capability Matrix](../model-capability-matrix.md) for the NLL type of each preset.
 
 ## Common Pitfalls

--- a/docs/benchmark/presets.md
+++ b/docs/benchmark/presets.md
@@ -20,7 +20,7 @@ A **preset** is a named model configuration that works immediately with `fit`, `
 | AutoSTPP | `auto_stpp` | `AutoSTPP` | Exact |
 | DeepSTPP | `deep_stpp` | `DeepSTPP` | Exact |
 | NSMPP DeepBasis | `nsmpp` | `NSMPP` | Exact |
-| NJSDE | `njsde` | `STPPEstimator("njsde")` | Exact |
+| NJSDE | `njsde` | `NJSDE` | Exact |
 | Neural JumpCNF | `neural_jumpcnf` | `NeuralJumpCNF` | Exact |
 | Neural AttnCNF | `neural_attncnf` | `NeuralAttnCNF` | Exact |
 | SMASH | `smash` | `SMASH` | Approximate |

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,123 +1,165 @@
-# Benchmark Campaigns
+# Benchmark
 
-!!! tip "When to use this"
-    Use the benchmark path for reproducible multi-preset, multi-dataset, multi-seed runs
-    with saved artifacts. For a single model in a notebook, the [Python API](python-api.md) is simpler.
+<p class="sh-ds-eyebrow">common datasets · shared splits · one evaluation protocol</p>
+
+Once a model is registered, it can be evaluated against every baseline on shared
+datasets under a common protocol. The headline comparison uses per-event negative
+log-likelihood (NLL), and the predictive and distributional metric profiles round
+out the picture, which matters for generative models that do not admit an exact
+likelihood. The command below runs your preset alongside several baselines and
+writes a comparable table.
+
+<div class="sh-bench-board" markdown="0">
+  <div class="sh-bench-matrix">
+    <div class="sh-bench-row sh-bench-row--head">
+      <span class="sh-bench-model sh-bench-model--head">preset</span>
+      <span class="sh-bench-col">COVID</span>
+      <span class="sh-bench-col">Earthquakes</span>
+      <span class="sh-bench-col">Citibike</span>
+    </div>
+    <div class="sh-bench-row sh-bench-row--you">
+      <span class="sh-bench-model"><span class="sh-bench-newchip">your model</span>my_preset</span>
+      <span class="sh-bench-cell"><span class="sh-bench-dot"></span></span>
+      <span class="sh-bench-cell"><span class="sh-bench-dot"></span></span>
+      <span class="sh-bench-cell"><span class="sh-bench-dot"></span></span>
+    </div>
+    <div class="sh-bench-row sh-bench-row--exact">
+      <span class="sh-bench-model">auto_stpp</span>
+      <span class="sh-bench-cell"><span class="sh-bench-dot"></span></span>
+      <span class="sh-bench-cell"><span class="sh-bench-dot"></span></span>
+      <span class="sh-bench-cell"><span class="sh-bench-dot"></span></span>
+    </div>
+    <div class="sh-bench-row sh-bench-row--exact">
+      <span class="sh-bench-model">deep_stpp</span>
+      <span class="sh-bench-cell"><span class="sh-bench-dot"></span></span>
+      <span class="sh-bench-cell"><span class="sh-bench-dot"></span></span>
+      <span class="sh-bench-cell"><span class="sh-bench-dot"></span></span>
+    </div>
+    <div class="sh-bench-row sh-bench-row--exact">
+      <span class="sh-bench-model">poisson_gmm</span>
+      <span class="sh-bench-cell"><span class="sh-bench-dot"></span></span>
+      <span class="sh-bench-cell"><span class="sh-bench-dot"></span></span>
+      <span class="sh-bench-cell"><span class="sh-bench-dot"></span></span>
+    </div>
+    <div class="sh-bench-row sh-bench-row--approx">
+      <span class="sh-bench-model">smash</span>
+      <span class="sh-bench-cell"><span class="sh-bench-dot"></span></span>
+      <span class="sh-bench-cell"><span class="sh-bench-dot"></span></span>
+      <span class="sh-bench-cell"><span class="sh-bench-dot"></span></span>
+    </div>
+    <div class="sh-bench-row sh-bench-row--approx">
+      <span class="sh-bench-model">diffusion_stpp</span>
+      <span class="sh-bench-cell"><span class="sh-bench-dot"></span></span>
+      <span class="sh-bench-cell"><span class="sh-bench-dot"></span></span>
+      <span class="sh-bench-cell"><span class="sh-bench-dot"></span></span>
+    </div>
+  </div>
+  <div class="sh-bench-legend">
+    <span><span class="sh-bench-rail sh-bench-rail--exact"></span>exact NLL · directly comparable</span>
+    <span><span class="sh-bench-rail sh-bench-rail--bound"></span>approximate NLL · a bound (ELBO, score-matching)</span>
+    <span><span class="sh-bench-keydot"></span>your model</span>
+  </div>
+</div>
+
+<p class="sh-bench-cap">Each cell is one <code>(preset × dataset × seed)</code> run, trained and evaluated under the same protocol. Results are written to <code>report.html</code> and the NLL tables.</p>
 
 ```bash
 python -m seahorse bench \
-  --presets poisson_gmm hawkes_gmm \
+  --presets my_preset auto_stpp deep_stpp poisson_gmm hawkes_gmm \
   --splits_dir splits \
   --seeds 1 2 3 \
-  --out runs/bench \
-  --n_workers 1
+  --out runs/bench
 ```
 
-## Inputs
+Replace `my_preset` with your registered name, and point `--splits_dir` at the
+core benchmark datasets (COVID, Earthquakes, Citibike). For a first run, the
+[small benchmark walkthrough](examples/run-a-small-benchmark.md) is a good place
+to start.
 
-For a collection of datasets, point `--splits_dir` at a directory:
+## The route
 
-```text
-splits/
-  dataset_a/train.jsonl  dataset_a/val.jsonl  dataset_a/test.jsonl
-  dataset_b/train.jsonl  dataset_b/val.jsonl  dataset_b/test.jsonl
-```
+<p class="sh-ds-eyebrow">from a single run to reported results</p>
 
-??? example "Show CLI command — single dataset or HuggingFace source"
-    ```bash
-    python -m seahorse bench \
-      --preset poisson_gmm \
-      --dataset owner/repo[/subdir] \
-      --dataset-revision main \
-      --seeds 1 \
-      --out runs/bench_one
-    ```
+<div class="sh-ext-paths" markdown="0">
+  <a class="sh-ext-path" href="../examples/run-a-small-benchmark/">
+    <span class="sh-ext-path-when">first run</span>
+    <span class="sh-ext-path-title">Run a small benchmark</span>
+    <span class="sh-ext-path-desc">A few presets on one dataset and seed: the walkthrough and the files it produces.</span>
+    <span class="sh-ext-path-go" aria-hidden="true">→</span>
+  </a>
+  <a class="sh-ext-path" href="../benchmark/compare/">
+    <span class="sh-ext-path-when">after a campaign</span>
+    <span class="sh-ext-path-title">Compare results</span>
+    <span class="sh-ext-path-desc">Read the NLL tables and line up models on individual sequences, within a comparable tier.</span>
+    <span class="sh-ext-path-go" aria-hidden="true">→</span>
+  </a>
+  <a class="sh-ext-path" href="../benchmark/tune/">
+    <span class="sh-ext-path-when">selecting hyperparameters</span>
+    <span class="sh-ext-path-title">Tune hyperparameters</span>
+    <span class="sh-ext-path-desc">Ray Tune HPO inside a campaign, with an explicit tuning dataset held out from the comparison.</span>
+    <span class="sh-ext-path-go" aria-hidden="true">→</span>
+  </a>
+  <a class="sh-ext-path" href="../benchmark/artifacts/">
+    <span class="sh-ext-path-when">reporting results</span>
+    <span class="sh-ext-path-title">Artifacts &amp; reproducibility</span>
+    <span class="sh-ext-path-desc">Every run directory, config, and table on disk, so a result reproduces months later.</span>
+    <span class="sh-ext-path-go" aria-hidden="true">→</span>
+  </a>
+</div>
 
-??? example "Show CLI command — filter specific datasets from a collection"
-    ```bash
-    python -m seahorse bench \
-      --presets poisson_gmm hawkes_gmm \
-      --splits_dir splits \
-      --datasets dataset_a dataset_b \
-      --seeds 1 \
-      --out runs/bench_subset
-    ```
+## Comparability
 
-## Model Families
+<p class="sh-ds-eyebrow">what every preset shares before its own code runs</p>
 
-| Family | Example presets | Notes |
-| --- | --- | --- |
-| Parametric baselines | `poisson_gmm`, `hawkes_gmm`, `selfcorrecting_gmm` | Compact temporal + GMM spatial. |
-| Flow spatial | `poisson_cnf`, `hawkes_cnf`, `selfcorrecting_cnf` | CNF spatial components. |
-| Time-varying CNF | `poisson_tvcnf`, `hawkes_tvcnf`, `selfcorrecting_tvcnf` | Time-conditioned flow spatial. |
-| Neural temporal | `rmtpp_gmm`, `thp_gmm` | Neural temporal + GMM spatial output. |
-| Neural STPP | `njsde`, `neural_jumpcnf`, `neural_attncnf` | Exact-density variants. |
-| Paper families | `auto_stpp`, `deep_stpp`, `smash`, `diffusion_stpp`, `nsmpp` | Registered presets and Python aliases. |
+Every `bench` run applies a shared contract: all presets receive the same train,
+validation, and test splits, the same normalization policy, and a per-event NLL
+computed by the same harness. A difference in the table therefore reflects the
+models rather than the experimental setup. The
+[execution contract](learn/execution-contract.md) records exactly what is held fixed.
 
-Use `python -m seahorse fit --help` for the current preset list.
+Models differ in how they express likelihood. Likelihood-based models report an
+exact NLL; generative families such as score-matching and diffusion models report
+an approximation, typically a bound on the log-likelihood (for example an ELBO).
+Both are informative once the distinction is kept in view, and they remain
+comparable when read in that light. Beyond NLL, the predictive and distributional
+[metric profiles](evaluation.md) give a fuller account of model quality, which is
+especially useful for models whose likelihood is only approximate.
 
-## Capability Notes
+<div class="sh-tier" markdown="0">
+  <div class="sh-tier-row sh-tier-row--exact">
+    <div class="sh-tier-label"><span class="sh-tier-name">Exact</span><span class="sh-tier-sub">directly comparable</span></div>
+    <div class="sh-tier-chips">
+      <span class="sh-fam">auto_stpp</span><span class="sh-fam">deep_stpp</span><span class="sh-fam">nsmpp</span><span class="sh-fam">njsde</span><span class="sh-fam">neural_*</span><span class="sh-fam">poisson_*</span><span class="sh-fam">hawkes_*</span><span class="sh-fam">rmtpp_gmm</span><span class="sh-fam">thp_gmm</span>
+    </div>
+  </div>
+  <div class="sh-tier-row sh-tier-row--approx">
+    <div class="sh-tier-label"><span class="sh-tier-name">Approximate</span><span class="sh-tier-sub">a bound on the likelihood</span></div>
+    <div class="sh-tier-chips">
+      <span class="sh-fam">smash <em>· score-matching</em></span><span class="sh-fam">diffusion_stpp <em>· ELBO</em></span>
+    </div>
+  </div>
+</div>
 
-- Exact likelihood paths support NLL-family metrics.
-- Native or exact sampling paths support next-event predictive metrics.
-- Surface diagnostics require an intensity grid or approximation path.
-- Unsupported combinations fail explicitly rather than silently.
+How a model declares its NLL type is covered in
+[capabilities](extend/capabilities.md).
 
-## Benchmark Policy
+## What a campaign leaves behind
 
-The benchmark config defaults to raw input coordinates and raw-space test NLL.
-Use `--normalize` only when you intentionally want z-scored time and space.
+Every run can be reproduced from disk. Alongside each fit's config, metrics, and
+checkpoint, a campaign writes:
 
-??? example "Show CLI command — short run with training overrides"
-    ```bash
-    python -m seahorse bench \
-      --presets poisson_gmm hawkes_gmm \
-      --splits_dir splits \
-      --seeds 1 \
-      --out runs/bench_short \
-      --override training.n_epochs=10 training.batch_size=64
-    ```
-
-## HPO Inside A Benchmark
-
-Benchmark HPO requires an explicit tuning dataset:
-
-??? example "Show CLI command — HPO benchmark"
-    ```bash
-    python -m seahorse bench \
-      --presets poisson_gmm hawkes_gmm \
-      --splits_dir splits \
-      --tune \
-      --tune-dataset dataset_a \
-      --n_trials 20 \
-      --seeds 1 2 3 \
-      --out runs/bench_hpo
-    ```
-
-??? example "Show CLI command — reuse previously tuned configs"
-    ```bash
-    python -m seahorse bench \
-      --presets poisson_gmm hawkes_gmm \
-      --splits_dir splits \
-      --hpo_configs_dir runs/hpo \
-      --seeds 1 \
-      --out runs/bench_reuse_hpo
-    ```
-
-## Outputs
-
-| File | Contents |
+| File | What it's for |
 | --- | --- |
-| `bench_meta.json` | Benchmark configuration and provenance |
-| `cell_index.json` | Index of benchmark cells and run directories |
-| `results.json` | Serialized run results |
-| `report.html` | Self-contained benchmark report |
-| `table_test_nll_all.csv` | NLL table over all reported runs |
-| `table_test_nll_exact.csv` | Exact/raw-space NLL table |
+| `report.html` | Self-contained comparison report, viewable in a browser |
+| `table_test_nll_all.csv` | Test NLL for every cell |
+| `table_test_nll_exact.csv` | The exact-NLL tier only |
+| `cell_index.json` | Maps each cell to its saved run directory |
 
-Each fit run also writes its own config, metrics, checkpoint, and `run_result.json`.
+Full layout and per-run files: [Artifacts and run directories](benchmark/artifacts.md).
 
-## Next Steps
+---
 
-- [Run A Small Benchmark](examples/run-a-small-benchmark.md) — concrete walkthrough.
-- [Evaluation And Visualization](evaluation.md) — post-fit metrics and plots.
+If you arrived from [Add your model](extend/overview.md), your model now appears in
+the same tables as the established baselines. From here, read the
+[comparison](benchmark/compare.md) or
+[reproduce the published results](paper-reproduction.md).

--- a/docs/cite.md
+++ b/docs/cite.md
@@ -1,0 +1,23 @@
+# Cite Seahorse
+
+If Seahorse helped your research, please cite it. A citation is the most direct
+way to support the project — and it helps other researchers find the tooling.
+
+!!! note "Paper coming soon"
+    The Seahorse paper is in preparation. Until the preprint is public, cite the
+    software release below; this page will be updated with the paper reference.
+
+## Software
+
+```bibtex
+@software{seahorse2026,
+  author  = {Aalaila, Yahya and contributors},
+  title   = {Seahorse: Unified benchmarking for spatio-temporal point processes},
+  year    = {2026},
+  url     = {https://github.com/YahyaAalaila/seahorse},
+  version = {0.1.0}
+}
+```
+
+Once a `CITATION.cff` is published in the repository, GitHub's **Cite this
+repository** button will offer the same entry in APA and BibTeX.

--- a/docs/datasets/catalog.md
+++ b/docs/datasets/catalog.md
@@ -2,21 +2,22 @@
 
 Thirteen ready-to-use spatio-temporal point-process datasets, hosted on the
 [`seahorse-stpp`](https://huggingface.co/seahorse-stpp) Hugging Face organization
-and loadable by id. They share one trait — events observed in **space and
-time** — but the meaning of "space" stretches from a city block to the human
+and loadable by a short name. They share one trait — events observed in **space
+and time** — but the meaning of "space" stretches from a city block to the human
 cortex. The catalog is ordered along that arc.
 
-Every dataset loads the same way:
+Every dataset loads the same way, by the short name shown on each card:
 
 ```python
 from seahorse.data import load_dataset
 
-splits = load_dataset("seahorse-stpp/citibike-stpp")  # {"train": [...], "val": [...], "test": [...]}
+splits = load_dataset("citibike")  # {"train": [...], "val": [...], "test": [...]}
 ```
 
-…or from the command line with `--dataset seahorse-stpp/<id>`. Three of them —
-marked **core benchmark** below — are the 2D-spatial trio used for the headline
-real-data comparison.
+…or from the command line with `--dataset citibike`. The full
+`seahorse-stpp/<id>` reference still works everywhere a short name does. Three of
+them — marked **core benchmark** below — are the 2D-spatial trio used for the
+headline real-data comparison.
 
 ## Moving through the city
 
@@ -25,21 +26,21 @@ real-data comparison.
 <div class="sh-ds-grid" markdown="0">
 <a class="sh-ds-card sh-ds-card--bench" href="https://huggingface.co/datasets/seahorse-stpp/citibike-stpp" target="_blank" rel="noopener">
   <span class="sh-ds-head"><span class="sh-ds-name">NYC Citibike</span><span class="sh-ds-chip">core benchmark</span></span>
-  <code class="sh-ds-id">seahorse-stpp/citibike-stpp</code>
+  <code class="sh-ds-id">citibike</code>
   <span class="sh-ds-desc">Bike-share trips between docking stations across New York City.</span>
   <span class="sh-ds-axes"><span class="sh-ds-axis"><span class="sh-ds-k">space</span>dock coordinates</span><span class="sh-ds-axis"><span class="sh-ds-k">time</span>ride start</span></span>
   <span class="sh-ds-go" aria-hidden="true">↗</span>
 </a>
 <a class="sh-ds-card" href="https://huggingface.co/datasets/seahorse-stpp/uber_pickups_nyc_stpp" target="_blank" rel="noopener">
   <span class="sh-ds-head"><span class="sh-ds-name">Uber Pickups · NYC</span></span>
-  <code class="sh-ds-id">seahorse-stpp/uber_pickups_nyc_stpp</code>
+  <code class="sh-ds-id">uber_pickups</code>
   <span class="sh-ds-desc">Ride-hailing pickup requests across New York City.</span>
   <span class="sh-ds-axes"><span class="sh-ds-axis"><span class="sh-ds-k">space</span>pickup location</span><span class="sh-ds-axis"><span class="sh-ds-k">time</span>request time</span></span>
   <span class="sh-ds-go" aria-hidden="true">↗</span>
 </a>
 <a class="sh-ds-card" href="https://huggingface.co/datasets/seahorse-stpp/us_accidents_stpp" target="_blank" rel="noopener">
   <span class="sh-ds-head"><span class="sh-ds-name">US Traffic Accidents</span></span>
-  <code class="sh-ds-id">seahorse-stpp/us_accidents_stpp</code>
+  <code class="sh-ds-id">us_accidents</code>
   <span class="sh-ds-desc">Road traffic accident reports across the United States.</span>
   <span class="sh-ds-axes"><span class="sh-ds-axis"><span class="sh-ds-k">space</span>accident location</span><span class="sh-ds-axis"><span class="sh-ds-k">time</span>report time</span></span>
   <span class="sh-ds-go" aria-hidden="true">↗</span>
@@ -53,28 +54,28 @@ real-data comparison.
 <div class="sh-ds-grid" markdown="0">
 <a class="sh-ds-card" href="https://huggingface.co/datasets/seahorse-stpp/chicago_crime_stpp" target="_blank" rel="noopener">
   <span class="sh-ds-head"><span class="sh-ds-name">Chicago Crime</span></span>
-  <code class="sh-ds-id">seahorse-stpp/chicago_crime_stpp</code>
+  <code class="sh-ds-id">chicago_crime</code>
   <span class="sh-ds-desc">Reported crime incidents across the city of Chicago.</span>
   <span class="sh-ds-axes"><span class="sh-ds-axis"><span class="sh-ds-k">space</span>block location</span><span class="sh-ds-axis"><span class="sh-ds-k">time</span>incident time</span></span>
   <span class="sh-ds-go" aria-hidden="true">↗</span>
 </a>
 <a class="sh-ds-card" href="https://huggingface.co/datasets/seahorse-stpp/la_crime_stpp" target="_blank" rel="noopener">
   <span class="sh-ds-head"><span class="sh-ds-name">LA Crime</span></span>
-  <code class="sh-ds-id">seahorse-stpp/la_crime_stpp</code>
+  <code class="sh-ds-id">la_crime</code>
   <span class="sh-ds-desc">Reported crime incidents across Los Angeles.</span>
   <span class="sh-ds-axes"><span class="sh-ds-axis"><span class="sh-ds-k">space</span>report location</span><span class="sh-ds-axis"><span class="sh-ds-k">time</span>incident time</span></span>
   <span class="sh-ds-go" aria-hidden="true">↗</span>
 </a>
 <a class="sh-ds-card" href="https://huggingface.co/datasets/seahorse-stpp/gtd_stpp" target="_blank" rel="noopener">
   <span class="sh-ds-head"><span class="sh-ds-name">Global Terrorism Database</span></span>
-  <code class="sh-ds-id">seahorse-stpp/gtd_stpp</code>
+  <code class="sh-ds-id">gtd</code>
   <span class="sh-ds-desc">Worldwide terrorism events from the GTD.</span>
   <span class="sh-ds-axes"><span class="sh-ds-axis"><span class="sh-ds-k">space</span>event location</span><span class="sh-ds-axis"><span class="sh-ds-k">time</span>event date</span></span>
   <span class="sh-ds-go" aria-hidden="true">↗</span>
 </a>
 <a class="sh-ds-card" href="https://huggingface.co/datasets/seahorse-stpp/austin_311_stpp" target="_blank" rel="noopener">
   <span class="sh-ds-head"><span class="sh-ds-name">Austin 311</span></span>
-  <code class="sh-ds-id">seahorse-stpp/austin_311_stpp</code>
+  <code class="sh-ds-id">austin_311</code>
   <span class="sh-ds-desc">Non-emergency city service requests in Austin, Texas.</span>
   <span class="sh-ds-axes"><span class="sh-ds-axis"><span class="sh-ds-k">space</span>request location</span><span class="sh-ds-axis"><span class="sh-ds-k">time</span>request time</span></span>
   <span class="sh-ds-go" aria-hidden="true">↗</span>
@@ -88,14 +89,14 @@ real-data comparison.
 <div class="sh-ds-grid" markdown="0">
 <a class="sh-ds-card sh-ds-card--bench" href="https://huggingface.co/datasets/seahorse-stpp/earthquakes-stpp" target="_blank" rel="noopener">
   <span class="sh-ds-head"><span class="sh-ds-name">Earthquakes</span><span class="sh-ds-chip">core benchmark</span></span>
-  <code class="sh-ds-id">seahorse-stpp/earthquakes-stpp</code>
+  <code class="sh-ds-id">earthquakes</code>
   <span class="sh-ds-desc">Seismic events with epicenter and origin time.</span>
   <span class="sh-ds-axes"><span class="sh-ds-axis"><span class="sh-ds-k">space</span>epicenter</span><span class="sh-ds-axis"><span class="sh-ds-k">time</span>origin time</span></span>
   <span class="sh-ds-go" aria-hidden="true">↗</span>
 </a>
 <a class="sh-ds-card" href="https://huggingface.co/datasets/seahorse-stpp/us_wildfires_stpp" target="_blank" rel="noopener">
   <span class="sh-ds-head"><span class="sh-ds-name">US Wildfires</span></span>
-  <code class="sh-ds-id">seahorse-stpp/us_wildfires_stpp</code>
+  <code class="sh-ds-id">us_wildfires</code>
   <span class="sh-ds-desc">Wildfire ignition records across the United States.</span>
   <span class="sh-ds-axes"><span class="sh-ds-axis"><span class="sh-ds-k">space</span>ignition location</span><span class="sh-ds-axis"><span class="sh-ds-k">time</span>discovery date</span></span>
   <span class="sh-ds-go" aria-hidden="true">↗</span>
@@ -109,7 +110,7 @@ real-data comparison.
 <div class="sh-ds-grid" markdown="0">
 <a class="sh-ds-card sh-ds-card--bench" href="https://huggingface.co/datasets/seahorse-stpp/covid-stpp" target="_blank" rel="noopener">
   <span class="sh-ds-head"><span class="sh-ds-name">COVID-19</span><span class="sh-ds-chip">core benchmark</span></span>
-  <code class="sh-ds-id">seahorse-stpp/covid-stpp</code>
+  <code class="sh-ds-id">covid</code>
   <span class="sh-ds-desc">Reported COVID-19 cases over space and time.</span>
   <span class="sh-ds-axes"><span class="sh-ds-axis"><span class="sh-ds-k">space</span>case location</span><span class="sh-ds-axis"><span class="sh-ds-k">time</span>report date</span></span>
   <span class="sh-ds-go" aria-hidden="true">↗</span>
@@ -123,14 +124,14 @@ real-data comparison.
 <div class="sh-ds-grid" markdown="0">
 <a class="sh-ds-card" href="https://huggingface.co/datasets/seahorse-stpp/gowalla_checkins_stpp" target="_blank" rel="noopener">
   <span class="sh-ds-head"><span class="sh-ds-name">Gowalla</span></span>
-  <code class="sh-ds-id">seahorse-stpp/gowalla_checkins_stpp</code>
+  <code class="sh-ds-id">gowalla</code>
   <span class="sh-ds-desc">Location-based social check-ins from the Gowalla network.</span>
   <span class="sh-ds-axes"><span class="sh-ds-axis"><span class="sh-ds-k">space</span>venue location</span><span class="sh-ds-axis"><span class="sh-ds-k">time</span>check-in time</span></span>
   <span class="sh-ds-go" aria-hidden="true">↗</span>
 </a>
 <a class="sh-ds-card" href="https://huggingface.co/datasets/seahorse-stpp/brightkite_checkins_stpp" target="_blank" rel="noopener">
   <span class="sh-ds-head"><span class="sh-ds-name">Brightkite</span></span>
-  <code class="sh-ds-id">seahorse-stpp/brightkite_checkins_stpp</code>
+  <code class="sh-ds-id">brightkite</code>
   <span class="sh-ds-desc">Location-based social check-ins from the Brightkite network.</span>
   <span class="sh-ds-axes"><span class="sh-ds-axis"><span class="sh-ds-k">space</span>venue location</span><span class="sh-ds-axis"><span class="sh-ds-k">time</span>check-in time</span></span>
   <span class="sh-ds-go" aria-hidden="true">↗</span>
@@ -144,7 +145,7 @@ real-data comparison.
 <div class="sh-ds-feature" markdown="0">
 <a class="sh-ds-card sh-ds-card--abstract" href="https://huggingface.co/datasets/seahorse-stpp/bold5000-stpp" target="_blank" rel="noopener">
   <span class="sh-ds-head"><span class="sh-ds-name">BOLD5000</span><span class="sh-ds-chip sh-ds-chip--muted">non-2D</span></span>
-  <code class="sh-ds-id">seahorse-stpp/bold5000-stpp</code>
+  <code class="sh-ds-id">bold5000</code>
   <span class="sh-ds-desc">Eventized neural responses derived from BOLD5000 fMRI recordings — included to show STPP space need not be geographic.</span>
   <span class="sh-ds-axes"><span class="sh-ds-axis"><span class="sh-ds-k">space</span>the brain</span><span class="sh-ds-axis"><span class="sh-ds-k">time</span>scan time</span></span>
   <span class="sh-ds-go" aria-hidden="true">↗</span>

--- a/docs/datasets/catalog.md
+++ b/docs/datasets/catalog.md
@@ -24,7 +24,7 @@ real-data comparison.
 
 <div class="sh-ds-grid" markdown="0">
 <a class="sh-ds-card sh-ds-card--bench" href="https://huggingface.co/datasets/seahorse-stpp/citibike-stpp" target="_blank" rel="noopener">
-  <span class="sh-ds-head"><span class="sh-ds-name">NYC Citi Bike</span><span class="sh-ds-chip">core benchmark</span></span>
+  <span class="sh-ds-head"><span class="sh-ds-name">NYC Citibike</span><span class="sh-ds-chip">core benchmark</span></span>
   <code class="sh-ds-id">seahorse-stpp/citibike-stpp</code>
   <span class="sh-ds-desc">Bike-share trips between docking stations across New York City.</span>
   <span class="sh-ds-axes"><span class="sh-ds-axis"><span class="sh-ds-k">space</span>dock coordinates</span><span class="sh-ds-axis"><span class="sh-ds-k">time</span>ride start</span></span>

--- a/docs/datasets/catalog.md
+++ b/docs/datasets/catalog.md
@@ -1,29 +1,163 @@
-# Dataset Sources
+# Dataset Catalog
 
-Seahorse works with any dataset that follows the JSONL split contract. The
-examples and Colab notebooks generate small synthetic datasets in that format so
-users can run the complete training and benchmark workflow without downloading
-external data.
+Thirteen ready-to-use spatio-temporal point-process datasets, hosted on the
+[`seahorse-stpp`](https://huggingface.co/seahorse-stpp) Hugging Face organization
+and loadable by id. They share one trait — events observed in **space and
+time** — but the meaning of "space" stretches from a city block to the human
+cortex. The catalog is ordered along that arc.
 
-## Expected Format
+Every dataset loads the same way:
 
-Any public Hugging Face dataset repository that exposes `train.jsonl`,
-`val.jsonl`, and `test.jsonl` at the repository root or a named subdirectory is
-usable with:
+```python
+from seahorse.data import load_dataset
 
-```bash
-python -m seahorse fit \
-  --preset poisson_gmm \
-  --dataset owner/repo[/subdir] \
-  --dataset-revision <revision> \
-  --out runs/fit
+splits = load_dataset("seahorse-stpp/citibike-stpp")  # {"train": [...], "val": [...], "test": [...]}
 ```
 
-Use pinned revisions for benchmark or paper runs so results remain reproducible.
+…or from the command line with `--dataset seahorse-stpp/<id>`. Three of them —
+marked **core benchmark** below — are the 2D-spatial trio used for the headline
+real-data comparison.
 
-## Preparing Your Own Data
+## Moving through the city
 
-If you have STPP data in a different format, see:
+<p class="sh-ds-eyebrow">space · streets, docks, and pickup points</p>
 
-- [Add Your Dataset](add-dataset.md) — checklist for preparing and registering a dataset.
-- [Conversion Standard](conversion.md) — how to convert from common formats (pandas DataFrame, NumPy, HDF5).
+<div class="sh-ds-grid" markdown="0">
+<a class="sh-ds-card sh-ds-card--bench" href="https://huggingface.co/datasets/seahorse-stpp/citibike-stpp" target="_blank" rel="noopener">
+  <span class="sh-ds-head"><span class="sh-ds-name">NYC Citi Bike</span><span class="sh-ds-chip">core benchmark</span></span>
+  <code class="sh-ds-id">seahorse-stpp/citibike-stpp</code>
+  <span class="sh-ds-desc">Bike-share trips between docking stations across New York City.</span>
+  <span class="sh-ds-axes"><span class="sh-ds-axis"><span class="sh-ds-k">space</span>dock coordinates</span><span class="sh-ds-axis"><span class="sh-ds-k">time</span>ride start</span></span>
+  <span class="sh-ds-go" aria-hidden="true">↗</span>
+</a>
+<a class="sh-ds-card" href="https://huggingface.co/datasets/seahorse-stpp/uber_pickups_nyc_stpp" target="_blank" rel="noopener">
+  <span class="sh-ds-head"><span class="sh-ds-name">Uber Pickups · NYC</span></span>
+  <code class="sh-ds-id">seahorse-stpp/uber_pickups_nyc_stpp</code>
+  <span class="sh-ds-desc">Ride-hailing pickup requests across New York City.</span>
+  <span class="sh-ds-axes"><span class="sh-ds-axis"><span class="sh-ds-k">space</span>pickup location</span><span class="sh-ds-axis"><span class="sh-ds-k">time</span>request time</span></span>
+  <span class="sh-ds-go" aria-hidden="true">↗</span>
+</a>
+<a class="sh-ds-card" href="https://huggingface.co/datasets/seahorse-stpp/us_accidents_stpp" target="_blank" rel="noopener">
+  <span class="sh-ds-head"><span class="sh-ds-name">US Traffic Accidents</span></span>
+  <code class="sh-ds-id">seahorse-stpp/us_accidents_stpp</code>
+  <span class="sh-ds-desc">Road traffic accident reports across the United States.</span>
+  <span class="sh-ds-axes"><span class="sh-ds-axis"><span class="sh-ds-k">space</span>accident location</span><span class="sh-ds-axis"><span class="sh-ds-k">time</span>report time</span></span>
+  <span class="sh-ds-go" aria-hidden="true">↗</span>
+</a>
+</div>
+
+## Incidents &amp; safety
+
+<p class="sh-ds-eyebrow">space · where something was reported</p>
+
+<div class="sh-ds-grid" markdown="0">
+<a class="sh-ds-card" href="https://huggingface.co/datasets/seahorse-stpp/chicago_crime_stpp" target="_blank" rel="noopener">
+  <span class="sh-ds-head"><span class="sh-ds-name">Chicago Crime</span></span>
+  <code class="sh-ds-id">seahorse-stpp/chicago_crime_stpp</code>
+  <span class="sh-ds-desc">Reported crime incidents across the city of Chicago.</span>
+  <span class="sh-ds-axes"><span class="sh-ds-axis"><span class="sh-ds-k">space</span>block location</span><span class="sh-ds-axis"><span class="sh-ds-k">time</span>incident time</span></span>
+  <span class="sh-ds-go" aria-hidden="true">↗</span>
+</a>
+<a class="sh-ds-card" href="https://huggingface.co/datasets/seahorse-stpp/la_crime_stpp" target="_blank" rel="noopener">
+  <span class="sh-ds-head"><span class="sh-ds-name">LA Crime</span></span>
+  <code class="sh-ds-id">seahorse-stpp/la_crime_stpp</code>
+  <span class="sh-ds-desc">Reported crime incidents across Los Angeles.</span>
+  <span class="sh-ds-axes"><span class="sh-ds-axis"><span class="sh-ds-k">space</span>report location</span><span class="sh-ds-axis"><span class="sh-ds-k">time</span>incident time</span></span>
+  <span class="sh-ds-go" aria-hidden="true">↗</span>
+</a>
+<a class="sh-ds-card" href="https://huggingface.co/datasets/seahorse-stpp/gtd_stpp" target="_blank" rel="noopener">
+  <span class="sh-ds-head"><span class="sh-ds-name">Global Terrorism Database</span></span>
+  <code class="sh-ds-id">seahorse-stpp/gtd_stpp</code>
+  <span class="sh-ds-desc">Worldwide terrorism events from the GTD.</span>
+  <span class="sh-ds-axes"><span class="sh-ds-axis"><span class="sh-ds-k">space</span>event location</span><span class="sh-ds-axis"><span class="sh-ds-k">time</span>event date</span></span>
+  <span class="sh-ds-go" aria-hidden="true">↗</span>
+</a>
+<a class="sh-ds-card" href="https://huggingface.co/datasets/seahorse-stpp/austin_311_stpp" target="_blank" rel="noopener">
+  <span class="sh-ds-head"><span class="sh-ds-name">Austin 311</span></span>
+  <code class="sh-ds-id">seahorse-stpp/austin_311_stpp</code>
+  <span class="sh-ds-desc">Non-emergency city service requests in Austin, Texas.</span>
+  <span class="sh-ds-axes"><span class="sh-ds-axis"><span class="sh-ds-k">space</span>request location</span><span class="sh-ds-axis"><span class="sh-ds-k">time</span>request time</span></span>
+  <span class="sh-ds-go" aria-hidden="true">↗</span>
+</a>
+</div>
+
+## Earth &amp; environment
+
+<p class="sh-ds-eyebrow">space · latitude and longitude on the globe</p>
+
+<div class="sh-ds-grid" markdown="0">
+<a class="sh-ds-card sh-ds-card--bench" href="https://huggingface.co/datasets/seahorse-stpp/earthquakes-stpp" target="_blank" rel="noopener">
+  <span class="sh-ds-head"><span class="sh-ds-name">Earthquakes</span><span class="sh-ds-chip">core benchmark</span></span>
+  <code class="sh-ds-id">seahorse-stpp/earthquakes-stpp</code>
+  <span class="sh-ds-desc">Seismic events with epicenter and origin time.</span>
+  <span class="sh-ds-axes"><span class="sh-ds-axis"><span class="sh-ds-k">space</span>epicenter</span><span class="sh-ds-axis"><span class="sh-ds-k">time</span>origin time</span></span>
+  <span class="sh-ds-go" aria-hidden="true">↗</span>
+</a>
+<a class="sh-ds-card" href="https://huggingface.co/datasets/seahorse-stpp/us_wildfires_stpp" target="_blank" rel="noopener">
+  <span class="sh-ds-head"><span class="sh-ds-name">US Wildfires</span></span>
+  <code class="sh-ds-id">seahorse-stpp/us_wildfires_stpp</code>
+  <span class="sh-ds-desc">Wildfire ignition records across the United States.</span>
+  <span class="sh-ds-axes"><span class="sh-ds-axis"><span class="sh-ds-k">space</span>ignition location</span><span class="sh-ds-axis"><span class="sh-ds-k">time</span>discovery date</span></span>
+  <span class="sh-ds-go" aria-hidden="true">↗</span>
+</a>
+</div>
+
+## Population health
+
+<p class="sh-ds-eyebrow">space · case geography</p>
+
+<div class="sh-ds-grid" markdown="0">
+<a class="sh-ds-card sh-ds-card--bench" href="https://huggingface.co/datasets/seahorse-stpp/covid-stpp" target="_blank" rel="noopener">
+  <span class="sh-ds-head"><span class="sh-ds-name">COVID-19</span><span class="sh-ds-chip">core benchmark</span></span>
+  <code class="sh-ds-id">seahorse-stpp/covid-stpp</code>
+  <span class="sh-ds-desc">Reported COVID-19 cases over space and time.</span>
+  <span class="sh-ds-axes"><span class="sh-ds-axis"><span class="sh-ds-k">space</span>case location</span><span class="sh-ds-axis"><span class="sh-ds-k">time</span>report date</span></span>
+  <span class="sh-ds-go" aria-hidden="true">↗</span>
+</a>
+</div>
+
+## Social check-ins
+
+<p class="sh-ds-eyebrow">space · where people check in</p>
+
+<div class="sh-ds-grid" markdown="0">
+<a class="sh-ds-card" href="https://huggingface.co/datasets/seahorse-stpp/gowalla_checkins_stpp" target="_blank" rel="noopener">
+  <span class="sh-ds-head"><span class="sh-ds-name">Gowalla</span></span>
+  <code class="sh-ds-id">seahorse-stpp/gowalla_checkins_stpp</code>
+  <span class="sh-ds-desc">Location-based social check-ins from the Gowalla network.</span>
+  <span class="sh-ds-axes"><span class="sh-ds-axis"><span class="sh-ds-k">space</span>venue location</span><span class="sh-ds-axis"><span class="sh-ds-k">time</span>check-in time</span></span>
+  <span class="sh-ds-go" aria-hidden="true">↗</span>
+</a>
+<a class="sh-ds-card" href="https://huggingface.co/datasets/seahorse-stpp/brightkite_checkins_stpp" target="_blank" rel="noopener">
+  <span class="sh-ds-head"><span class="sh-ds-name">Brightkite</span></span>
+  <code class="sh-ds-id">seahorse-stpp/brightkite_checkins_stpp</code>
+  <span class="sh-ds-desc">Location-based social check-ins from the Brightkite network.</span>
+  <span class="sh-ds-axes"><span class="sh-ds-axis"><span class="sh-ds-k">space</span>venue location</span><span class="sh-ds-axis"><span class="sh-ds-k">time</span>check-in time</span></span>
+  <span class="sh-ds-go" aria-hidden="true">↗</span>
+</a>
+</div>
+
+## Beyond the map
+
+<p class="sh-ds-eyebrow">space · not a map at all</p>
+
+<div class="sh-ds-grid" markdown="0">
+<a class="sh-ds-card sh-ds-card--abstract" href="https://huggingface.co/datasets/seahorse-stpp/bold5000-stpp" target="_blank" rel="noopener">
+  <span class="sh-ds-head"><span class="sh-ds-name">BOLD5000</span><span class="sh-ds-chip sh-ds-chip--muted">non-2D</span></span>
+  <code class="sh-ds-id">seahorse-stpp/bold5000-stpp</code>
+  <span class="sh-ds-desc">Eventized neural responses derived from BOLD5000 fMRI recordings — included to show STPP space need not be geographic.</span>
+  <span class="sh-ds-axes"><span class="sh-ds-axis"><span class="sh-ds-k">space</span>the brain</span><span class="sh-ds-axis"><span class="sh-ds-k">time</span>scan time</span></span>
+  <span class="sh-ds-go" aria-hidden="true">↗</span>
+</a>
+</div>
+
+!!! note "BOLD5000 is supported, not part of the headline benchmark"
+    BOLD5000 ships as a fully supported dataset, but the main real-data
+    comparison stays on the 2D-spatial trio — **COVID, Earthquakes, and
+    Citibike** — because several benchmark presets are built for
+    two-dimensional spatial event domains.
+
+---
+
+Want to add your own? See [Add Your Dataset](add-dataset.md) for the preparation
+checklist and [Conversion Standard](conversion.md) for the JSONL format.

--- a/docs/datasets/catalog.md
+++ b/docs/datasets/catalog.md
@@ -157,6 +157,24 @@ real-data comparison.
     Citibike** — because several benchmark presets are built for
     two-dimensional spatial event domains.
 
+## Synthetic benchmark suites
+
+<p class="sh-ds-eyebrow">space · whatever you configure it to be</p>
+
+When you need known ground truth — to isolate one factor that real data
+confounds — Seahorse uses synthetic sequences from
+[HawkesNest](https://github.com/YahyaAalaila/HawkesNest).
+
+<div class="sh-ds-grid" markdown="0">
+<a class="sh-ds-card sh-ds-card--synth sh-ds-card--wide" href="https://github.com/YahyaAalaila/HawkesNest" target="_blank" rel="noopener">
+  <span class="sh-ds-head"><span class="sh-ds-name">HawkesNest · entanglement suite</span><span class="sh-ds-chip sh-ds-chip--synth">synthetic</span></span>
+  <code class="sh-ds-id">github.com/YahyaAalaila/HawkesNest</code>
+  <span class="sh-ds-desc">Spatio-temporal sequences generated with tunable <em>entanglement</em> between the space and time dimensions, under known ground truth — so a model's behaviour can be probed against a factor that real-world data cannot cleanly separate.</span>
+  <span class="sh-ds-axes"><span class="sh-ds-axis"><span class="sh-ds-k">space</span>configurable domain</span><span class="sh-ds-axis"><span class="sh-ds-k">time</span>configurable process</span></span>
+  <span class="sh-ds-go" aria-hidden="true">↗</span>
+</a>
+</div>
+
 ---
 
 Want to add your own? See [Add Your Dataset](add-dataset.md) for the preparation

--- a/docs/datasets/catalog.md
+++ b/docs/datasets/catalog.md
@@ -141,7 +141,7 @@ real-data comparison.
 
 <p class="sh-ds-eyebrow">space · not a map at all</p>
 
-<div class="sh-ds-grid" markdown="0">
+<div class="sh-ds-feature" markdown="0">
 <a class="sh-ds-card sh-ds-card--abstract" href="https://huggingface.co/datasets/seahorse-stpp/bold5000-stpp" target="_blank" rel="noopener">
   <span class="sh-ds-head"><span class="sh-ds-name">BOLD5000</span><span class="sh-ds-chip sh-ds-chip--muted">non-2D</span></span>
   <code class="sh-ds-id">seahorse-stpp/bold5000-stpp</code>
@@ -149,13 +149,11 @@ real-data comparison.
   <span class="sh-ds-axes"><span class="sh-ds-axis"><span class="sh-ds-k">space</span>the brain</span><span class="sh-ds-axis"><span class="sh-ds-k">time</span>scan time</span></span>
   <span class="sh-ds-go" aria-hidden="true">↗</span>
 </a>
+<div class="sh-ds-aside">
+  <span class="sh-ds-aside-title">Supported — but not in the headline benchmark</span>
+  <p>BOLD5000 ships as a fully supported dataset. The main real-data comparison stays on the 2D-spatial trio — <strong>COVID</strong>, <strong>Earthquakes</strong>, and <strong>Citibike</strong> — because several benchmark presets are built for two-dimensional spatial event domains.</p>
 </div>
-
-!!! note "BOLD5000 is supported, not part of the headline benchmark"
-    BOLD5000 ships as a fully supported dataset, but the main real-data
-    comparison stays on the 2D-spatial trio — **COVID, Earthquakes, and
-    Citibike** — because several benchmark presets are built for
-    two-dimensional spatial event domains.
+</div>
 
 ## Synthetic benchmark suites
 

--- a/docs/datasets/hf-datasets.md
+++ b/docs/datasets/hf-datasets.md
@@ -33,15 +33,22 @@ python -m seahorse bench \
 
 ## Python API
 
-The Python API does not download HuggingFace datasets automatically. Download and cache the splits first, then load with `load_jsonl`:
+`load_dataset` resolves a HuggingFace repo id (or a curated `seahorse-stpp`
+name), downloads the splits, caches them, and returns parsed sequences:
+
+```python
+from seahorse.data import load_dataset
+
+splits = load_dataset("seahorse-stpp/citibike-stpp")
+train, val, test = splits["train"], splits["val"], splits["test"]
+```
+
+For splits already on local disk, use `load_jsonl` directly:
 
 ```python
 from seahorse import load_jsonl
 
-# After downloading splits to a local directory:
 train = load_jsonl("cache/my_dataset/train.jsonl")
-val   = load_jsonl("cache/my_dataset/val.jsonl")
-test  = load_jsonl("cache/my_dataset/test.jsonl")
 ```
 
 ## Hosting Your Own Dataset on HuggingFace
@@ -55,4 +62,8 @@ See [Conversion Standard](conversion.md) for format details and [Add Your Datase
 
 ## Dataset Catalog
 
-See [Dataset Catalog](catalog.md) for a list of known-working public datasets.
+Seahorse curates **13 ready-to-use datasets** in the
+[`seahorse-stpp`](https://huggingface.co/seahorse-stpp) organization, spanning
+urban mobility, crime, natural hazards, public health, social check-ins, and
+neuroimaging. Browse them — with load snippets and per-dataset space/time axes —
+in the **[Dataset Catalog](catalog.md)**.

--- a/docs/datasets/hf-datasets.md
+++ b/docs/datasets/hf-datasets.md
@@ -39,7 +39,7 @@ name), downloads the splits, caches them, and returns parsed sequences:
 ```python
 from seahorse.data import load_dataset
 
-splits = load_dataset("seahorse-stpp/citibike-stpp")
+splits = load_dataset("citibike")
 train, val, test = splits["train"], splits["val"], splits["test"]
 ```
 

--- a/docs/datasets/overview.md
+++ b/docs/datasets/overview.md
@@ -26,19 +26,40 @@ Each file is one JSON object per line. Each object is one event sequence.
 
 | Source | How to use |
 | --- | --- |
+| Curated `seahorse-stpp` datasets | `load_dataset("seahorse-stpp/<id>")` or `--dataset seahorse-stpp/<id>` |
+| Any Hugging Face repo | Pass `--dataset owner/repo[/subdir]` — Seahorse downloads and caches |
 | Local JSONL files | Pass `--train`, `--val`, `--test` flags or a directory with `--dataset` |
 | Local split collection | Point `--splits_dir` at a root with one subdirectory per dataset |
-| Hugging Face Hub | Pass `--dataset owner/repo[/subdir]` — Seahorse downloads and caches |
 
 See [Data Format](../data-format.md) for the full contract and command support matrix.
 
 ## Ready-to-use Datasets
 
-Seahorse is designed to work with HuggingFace-hosted STPP datasets that follow the JSONL split convention. See [Ready-to-use HF Datasets](hf-datasets.md) for sources.
+Seahorse curates **13 real-world STPP datasets** in the
+[`seahorse-stpp`](https://huggingface.co/seahorse-stpp) Hugging Face
+organization — spanning urban mobility, crime, natural hazards, public health,
+social check-ins, and even neuroimaging — all in the same JSONL split format.
+Load any of them by id:
+
+```python
+from seahorse.data import load_dataset
+
+splits = load_dataset("seahorse-stpp/citibike-stpp")  # downloads + caches
+```
+
+Browse the full collection, with load snippets and each dataset's space/time
+axes, in the **[Dataset Catalog](catalog.md)**.
+
+Need controlled ground truth? Seahorse's synthetic benchmark sequences are
+generated with [HawkesNest](https://github.com/YahyaAalaila/HawkesNest) — its
+**entanglement suite** produces spatio-temporal data with tunable space–time
+coupling for stress-testing models. See
+[Synthetic benchmark suites](catalog.md#synthetic-benchmark-suites).
 
 ## Next Steps
 
+- [Dataset Catalog](catalog.md) — browse the 13 ready-to-use datasets.
 - [Data Format](../data-format.md) — detailed format specification and command matrix.
-- [Ready-to-use HF Datasets](hf-datasets.md) — pre-formatted datasets you can use immediately.
+- [Ready-to-use HF Datasets](hf-datasets.md) — load by repo id, or host your own.
 - [Add Your Dataset](add-dataset.md) — how to prepare your own data.
 - [Conversion Standard](conversion.md) — how to convert from common formats.

--- a/docs/datasets/overview.md
+++ b/docs/datasets/overview.md
@@ -26,7 +26,7 @@ Each file is one JSON object per line. Each object is one event sequence.
 
 | Source | How to use |
 | --- | --- |
-| Curated `seahorse-stpp` datasets | `load_dataset("seahorse-stpp/<id>")` or `--dataset seahorse-stpp/<id>` |
+| Curated `seahorse-stpp` datasets | `load_dataset("citibike")` or `--dataset citibike` (short name) |
 | Any Hugging Face repo | Pass `--dataset owner/repo[/subdir]` — Seahorse downloads and caches |
 | Local JSONL files | Pass `--train`, `--val`, `--test` flags or a directory with `--dataset` |
 | Local split collection | Point `--splits_dir` at a root with one subdirectory per dataset |
@@ -39,12 +39,12 @@ Seahorse curates **13 real-world STPP datasets** in the
 [`seahorse-stpp`](https://huggingface.co/seahorse-stpp) Hugging Face
 organization — spanning urban mobility, crime, natural hazards, public health,
 social check-ins, and even neuroimaging — all in the same JSONL split format.
-Load any of them by id:
+Load any of them by its short name:
 
 ```python
 from seahorse.data import load_dataset
 
-splits = load_dataset("seahorse-stpp/citibike-stpp")  # downloads + caches
+splits = load_dataset("citibike")  # downloads + caches
 ```
 
 Browse the full collection, with load snippets and each dataset's space/time

--- a/docs/examples/case-study.md
+++ b/docs/examples/case-study.md
@@ -18,7 +18,7 @@ plots the predictions — all on CPU, in a few minutes.
     <span class="sh-ext-num">1</span>
     <div class="sh-ext-step-body">
       <span class="sh-ext-step-title">Install and load real data</span>
-      <p><code>pip install seahorse-stpp</code>, then <code>load_dataset("seahorse-stpp/citibike-stpp")</code> pulls the Citibike splits straight from the Hugging Face hub — no manual download.</p>
+      <p><code>pip install seahorse-stpp</code>, then <code>load_dataset("citibike")</code> pulls the Citibike splits straight from the Hugging Face hub — no manual download.</p>
     </div>
   </li>
   <li class="sh-ext-step">

--- a/docs/examples/case-study.md
+++ b/docs/examples/case-study.md
@@ -1,98 +1,57 @@
 # End-to-End Case Study
 
-This case study shows the complete Seahorse workflow on a small JSONL dataset:
-inspect the data contract, fit a model, run a benchmark, and inspect saved
-artifacts. It is the recommended path for new users who want to understand how
-the repository works before moving to larger datasets.
+Real dataset, real numbers, one click. This is the fastest way to watch Seahorse
+do something real: it installs from PyPI, loads the **Citibike** spatio-temporal
+dataset, trains a baseline and a neural model, scores both under one metric, and
+plots the predictions — all on CPU, in a few minutes.
 
-## 1. Start From The Data Contract
+<a class="sh-colab-cta" href="https://colab.research.google.com/github/YahyaAalaila/seahorse/blob/main/docs/notebooks/01_run_one_model_python_api.ipynb" target="_blank" rel="noopener">
+  <span class="sh-colab-badge" aria-hidden="true">▶</span>
+  <span class="sh-colab-text"><strong>Open the case study in Colab</strong><span>Citibike · CPU-only · no local setup</span></span>
+  <span class="sh-colab-go" aria-hidden="true">↗</span>
+</a>
 
-Seahorse expects three JSONL split files:
+## What the notebook walks through
 
-```text
-data/my_dataset/
-  train.jsonl
-  val.jsonl
-  test.jsonl
-```
+<ol class="sh-ext-steps" markdown="0">
+  <li class="sh-ext-step">
+    <span class="sh-ext-num">1</span>
+    <div class="sh-ext-step-body">
+      <span class="sh-ext-step-title">Install and load real data</span>
+      <p><code>pip install seahorse-stpp</code>, then <code>load_dataset("seahorse-stpp/citibike-stpp")</code> pulls the Citibike splits straight from the Hugging Face hub — no manual download.</p>
+    </div>
+  </li>
+  <li class="sh-ext-step">
+    <span class="sh-ext-num">2</span>
+    <div class="sh-ext-step-body">
+      <span class="sh-ext-step-title">Train a baseline and a neural model</span>
+      <p>Fit <code>PoissonGMM</code> as a fast parametric baseline and <code>DeepSTPP</code> as the neural model — the same <code>fit()</code> call for both.</p>
+    </div>
+  </li>
+  <li class="sh-ext-step">
+    <span class="sh-ext-num">3</span>
+    <div class="sh-ext-step-body">
+      <span class="sh-ext-step-title">Evaluate head-to-head</span>
+      <p>Score both on held-out test sequences and compare <code>test_nll</code> under one shared metric definition — comparable by construction.</p>
+    </div>
+  </li>
+  <li class="sh-ext-step">
+    <span class="sh-ext-num">4</span>
+    <div class="sh-ext-step-body">
+      <span class="sh-ext-step-title">Visualize the predictions</span>
+      <p>Sample next events with <code>predict_next</code> and plot the sampled locations against the true next event.</p>
+    </div>
+  </li>
+</ol>
 
-Each line is one event sequence:
+## Why this dataset
 
-```json
-{"times": [0.1, 0.4, 1.2], "locations": [[0.2, 0.4], [0.3, 0.8], [0.7, 0.1]]}
-```
+- **Real, not synthetic** — Citibike is the lightest real public dataset in the [catalog](../datasets/catalog.md), so it runs on a free CPU runtime.
+- **Comparable by construction** — the baseline and the neural model share the same splits, normalization, and metric, so the numbers actually mean something.
+- **One click** — the notebook installs the published package; nothing to clone or configure.
 
-The Colab tutorials generate this layout automatically, so a new user can run
-the workflow without downloading data.
+## Then go deeper
 
-## 2. Fit One Model
-
-Use the Python API for a focused single-model experiment:
-
-```python
-from seahorse import AutoSTPP, load_jsonl
-
-train = load_jsonl("data/my_dataset/train.jsonl")
-val = load_jsonl("data/my_dataset/val.jsonl")
-test = load_jsonl("data/my_dataset/test.jsonl")
-
-model = AutoSTPP(device="cpu", seed=42)
-model.fit(train, val, test, epochs=10, batch_size=64)
-scores = model.evaluate(test)
-samples = model.predict_next(test, n_samples=32)
-```
-
-Open the executable walkthrough:
-[Run One Model With The Python API](colabs.md).
-
-## 3. Run A Benchmark Campaign
-
-Use the CLI when comparing presets or preserving benchmark artifacts:
-
-```bash
-python -m seahorse bench \
-  --presets poisson_gmm hawkes_gmm auto_stpp deep_stpp \
-  --dataset data/my_dataset \
-  --seeds 1 \
-  --out runs/examples/small_benchmark \
-  --n_workers 1
-```
-
-The benchmark path records the preset, dataset source, seed, overrides, and run
-directory for each benchmark cell. Open the executable walkthrough:
-[Benchmark Models With The CLI](colabs.md).
-
-## 4. Inspect The Artifacts
-
-A benchmark directory contains campaign-level tables and per-run directories:
-
-```text
-runs/examples/small_benchmark/
-  bench_meta.json
-  cell_index.json
-  results.json
-  table_test_nll_all.csv
-```
-
-Use `cell_index.json` to find a saved run and evaluate additional metric
-profiles:
-
-```bash
-python -m seahorse evaluate metrics \
-  --run path/to/run_dir \
-  --data data/my_dataset/test.jsonl \
-  --split test \
-  --metric-profile core \
-  --out runs/examples/small_benchmark/evaluate_core
-```
-
-## 5. Scale The Same Pattern
-
-After the case study runs, scale in three directions:
-
-- replace the demo data with your own JSONL splits;
-- add presets and seeds to the benchmark campaign;
-- pin dataset revisions and commit hashes for paper-grade reproducibility.
-
-The same data contract, CLI commands, and artifact layout apply to larger
-experiments.
+- [Dataset Catalog](../datasets/catalog.md) — swap Citibike for any of the 13 datasets.
+- [Run a Benchmark](run-a-small-benchmark.md) — compare many presets and seeds.
+- [Python API](../python-api.md) — the full programmatic surface behind the notebook.

--- a/docs/examples/train-one-model.md
+++ b/docs/examples/train-one-model.md
@@ -8,30 +8,48 @@ inside a script or notebook.
 Use <a href="https://colab.research.google.com/github/YahyaAalaila/seahorse/blob/main/docs/notebooks/01_run_one_model_python_api.ipynb">01 Run One Model With The Python API</a>
 for an executable walkthrough in Google Colab.
 
-## Python API Example
+## Data → Model → Fit → Evaluate
+
+Three short stages take you from raw splits to scored predictions.
+
+<p class="sh-stage-label"><span class="sh-stage-num">1</span> Load the splits</p>
 
 ```python
-from seahorse import AutoSTPP, load_jsonl
+from seahorse import load_jsonl
 
 train = load_jsonl("data/my_dataset/train.jsonl")
 val   = load_jsonl("data/my_dataset/val.jsonl")
 test  = load_jsonl("data/my_dataset/test.jsonl")
+```
+
+<p class="sh-stage-label"><span class="sh-stage-num">2</span> Build and fit a model</p>
+
+```python
+from seahorse import AutoSTPP
 
 model = AutoSTPP(device="cpu", seed=42)
 model.fit(train, val, test, epochs=10, batch_size=64, dataset_id="my_dataset")
+```
 
+<p class="sh-stage-label"><span class="sh-stage-num">3</span> Evaluate and sample</p>
+
+```python
 scores  = model.evaluate(test)
 samples = model.predict_next(test, n_samples=32)
 
-print(scores)
+print(scores)                        # {"test_nll": ..., "mean_seq_nll": ...}
 print(samples["next_times"].shape)
 ```
 
-`fit()` requires a validation split. `evaluate()` supports the Python-facing
-likelihood metrics `test_nll` and `mean_seq_nll`. For benchmark metric profiles
-and artifact-backed reports, use the CLI.
+!!! note "Two small rules"
+    `fit()` requires a validation split. `evaluate()` returns the Python-facing
+    likelihood metrics `test_nll` and `mean_seq_nll` — for benchmark metric
+    profiles and artifact-backed reports, use the CLI.
 
-??? example "Show Python example — try a baseline"
+## Variations
+
+=== "Compare a baseline"
+
     ```python
     from seahorse import PoissonGMM
 
@@ -40,7 +58,8 @@ and artifact-backed reports, use the CLI.
     print(baseline.evaluate(test))
     ```
 
-??? example "Show Python example — save and reload"
+=== "Save and reload"
+
     ```python
     save_dir = model.save("runs/api/auto_stpp")
     loaded   = AutoSTPP.load(save_dir)

--- a/docs/extend/capabilities.md
+++ b/docs/extend/capabilities.md
@@ -2,16 +2,49 @@
 
 Seahorse evaluation profiles are gated by **capability flags**. Before adding a preset to benchmark examples, decide which capabilities it supports and verify them with explicit tests.
 
-## Capability Flags
+## What each capability unlocks
 
-| Capability | What it enables | How to declare |
-| --- | --- | --- |
-| **Exact NLL** | `core` and `nll` metric profiles; benchmark NLL tables | `EventModel.log_prob()` returns exact log-likelihood |
-| **Approximate NLL** | Included in tables but flagged as approximate | `log_prob()` returns a surrogate (score-matching, ELBO) |
-| **Next-event sampling** | `predictive` metric profile; `predict_next` Python method | `EventModel.sample_next()` implemented |
-| **Generative rollouts** | `generative` and `autoregressive` profiles | Sampling path supports multi-step rollout |
-| **Intensity surface** | `surface` profile via `evaluate surface` | `EventModel` exposes an intensity or density grid query |
-| **Save / load** | `STPPEstimator.load()`, re-evaluation from disk | Works automatically via runner checkpoint |
+Each capability is a method you implement. Implement it → its metrics turn on.
+Skip it → those metrics report a clean skip, never a wrong number.
+
+<div class="sh-cap-grid" markdown="0">
+  <div class="sh-cap sh-cap--exact">
+    <div class="sh-cap-top"><span class="sh-cap-name">Exact NLL</span><span class="sh-cap-tag">exact</span></div>
+    <span class="sh-cap-by">declared by <code>log_prob()</code> returning an exact log-likelihood</span>
+    <span class="sh-cap-unlocks">unlocks</span>
+    <div class="sh-cap-chips"><span class="sh-cap-chip">core</span><span class="sh-cap-chip">nll</span><span class="sh-cap-chip">benchmark NLL tables</span></div>
+  </div>
+  <div class="sh-cap sh-cap--approx">
+    <div class="sh-cap-top"><span class="sh-cap-name">Approximate NLL</span><span class="sh-cap-tag">approx</span></div>
+    <span class="sh-cap-by">declared by <code>log_prob()</code> returning a surrogate (score-matching, ELBO)</span>
+    <span class="sh-cap-unlocks">unlocks</span>
+    <div class="sh-cap-chips"><span class="sh-cap-chip">nll tables · flagged approximate</span></div>
+  </div>
+  <div class="sh-cap sh-cap--optional">
+    <div class="sh-cap-top"><span class="sh-cap-name">Next-event sampling</span><span class="sh-cap-tag">optional</span></div>
+    <span class="sh-cap-by">declared by implementing <code>sample_next()</code></span>
+    <span class="sh-cap-unlocks">unlocks</span>
+    <div class="sh-cap-chips"><span class="sh-cap-chip">predictive</span><span class="sh-cap-chip">predict_next</span></div>
+  </div>
+  <div class="sh-cap sh-cap--optional">
+    <div class="sh-cap-top"><span class="sh-cap-name">Generative rollouts</span><span class="sh-cap-tag">optional</span></div>
+    <span class="sh-cap-by">declared by a sampling path that supports multi-step rollout</span>
+    <span class="sh-cap-unlocks">unlocks</span>
+    <div class="sh-cap-chips"><span class="sh-cap-chip">generative</span><span class="sh-cap-chip">autoregressive</span></div>
+  </div>
+  <div class="sh-cap sh-cap--optional">
+    <div class="sh-cap-top"><span class="sh-cap-name">Intensity surface</span><span class="sh-cap-tag">optional</span></div>
+    <span class="sh-cap-by">declared by implementing <code>intensity_grid()</code></span>
+    <span class="sh-cap-unlocks">unlocks</span>
+    <div class="sh-cap-chips"><span class="sh-cap-chip">surface</span><span class="sh-cap-chip">evaluate surface</span></div>
+  </div>
+  <div class="sh-cap sh-cap--auto">
+    <div class="sh-cap-top"><span class="sh-cap-name">Save / load</span><span class="sh-cap-tag">automatic</span></div>
+    <span class="sh-cap-by">works for free via the runner checkpoint — nothing to implement</span>
+    <span class="sh-cap-unlocks">unlocks</span>
+    <div class="sh-cap-chips"><span class="sh-cap-chip">STPPEstimator.load()</span><span class="sh-cap-chip">re-evaluation from disk</span></div>
+  </div>
+</div>
 
 ## Declaring in EventModel
 
@@ -35,13 +68,25 @@ class MyEventModel(nn.Module):
 
 When a method raises `NotImplementedError`, the corresponding metric is marked `available: false` in `metrics.json` with a clear reason — it is not treated as a failure.
 
-## Exact vs Approximate NLL
+## Exact vs approximate NLL
 
-| Families | NLL type | Comparable? |
-| --- | --- | --- |
-| `auto_stpp`, `deep_stpp`, `nsmpp`, `njsde`, `neural_*`, `poisson_*`, `hawkes_*`, `rmtpp_gmm`, `thp_gmm` | Exact | Yes — directly comparable in benchmark tables |
-| `smash` | Score-matching surrogate | Note in tables; not directly comparable to exact families |
-| `diffusion_stpp` | ELBO | Note in tables; not directly comparable to exact families |
+NLL is only comparable across families that compute it the same way. Seahorse
+keeps the two tiers visibly separate in benchmark tables.
+
+<div class="sh-tier" markdown="0">
+  <div class="sh-tier-row sh-tier-row--exact">
+    <div class="sh-tier-label"><span class="sh-tier-name">Exact</span><span class="sh-tier-sub">directly comparable</span></div>
+    <div class="sh-tier-chips">
+      <span class="sh-fam">auto_stpp</span><span class="sh-fam">deep_stpp</span><span class="sh-fam">nsmpp</span><span class="sh-fam">njsde</span><span class="sh-fam">neural_*</span><span class="sh-fam">poisson_*</span><span class="sh-fam">hawkes_*</span><span class="sh-fam">rmtpp_gmm</span><span class="sh-fam">thp_gmm</span>
+    </div>
+  </div>
+  <div class="sh-tier-row sh-tier-row--approx">
+    <div class="sh-tier-label"><span class="sh-tier-name">Approximate</span><span class="sh-tier-sub">flagged, not directly comparable</span></div>
+    <div class="sh-tier-chips">
+      <span class="sh-fam">smash <em>· score-matching</em></span><span class="sh-fam">diffusion_stpp <em>· ELBO</em></span>
+    </div>
+  </div>
+</div>
 
 ## Capability Testing
 

--- a/docs/extend/capabilities.md
+++ b/docs/extend/capabilities.md
@@ -18,7 +18,7 @@ Skip it → those metrics report a clean skip, never a wrong number.
     <div class="sh-cap-top"><span class="sh-cap-name">Bounded NLL</span><span class="sh-cap-tag">bound</span></div>
     <span class="sh-cap-by">declared by <code>log_prob()</code> returning a surrogate (score-matching, ELBO)</span>
     <span class="sh-cap-unlocks">unlocks</span>
-    <div class="sh-cap-chips"><span class="sh-cap-chip">nll tables · flagged non-exact</span></div>
+    <div class="sh-cap-chips"><span class="sh-cap-chip">nll tables · non-exact</span></div>
   </div>
   <div class="sh-cap sh-cap--optional">
     <div class="sh-cap-top"><span class="sh-cap-name">Next-event sampling</span><span class="sh-cap-tag">optional</span></div>
@@ -78,7 +78,7 @@ keeps the two tiers visibly separate in benchmark tables.
     </div>
   </div>
   <div class="sh-tier-row sh-tier-row--approx">
-    <div class="sh-tier-label"><span class="sh-tier-name">Approximate</span><span class="sh-tier-sub">flagged, not directly comparable</span></div>
+    <div class="sh-tier-label"><span class="sh-tier-name">Approximate</span><span class="sh-tier-sub">a bound on the likelihood</span></div>
     <div class="sh-tier-chips">
       <span class="sh-fam">smash <em>· score-matching</em></span><span class="sh-fam">diffusion_stpp <em>· ELBO</em></span>
     </div>

--- a/docs/extend/capabilities.md
+++ b/docs/extend/capabilities.md
@@ -15,7 +15,7 @@ Skip it → those metrics report a clean skip, never a wrong number.
     <div class="sh-cap-chips"><span class="sh-cap-chip">core</span><span class="sh-cap-chip">nll</span><span class="sh-cap-chip">benchmark NLL tables</span></div>
   </div>
   <div class="sh-cap sh-cap--approx">
-    <div class="sh-cap-top"><span class="sh-cap-name">Approximate NLL</span><span class="sh-cap-tag">approx</span></div>
+    <div class="sh-cap-top"><span class="sh-cap-name">Bounded NLL</span><span class="sh-cap-tag">bound</span></div>
     <span class="sh-cap-by">declared by <code>log_prob()</code> returning a surrogate (score-matching, ELBO)</span>
     <span class="sh-cap-unlocks">unlocks</span>
     <div class="sh-cap-chips"><span class="sh-cap-chip">nll tables · flagged approximate</span></div>
@@ -38,13 +38,10 @@ Skip it → those metrics report a clean skip, never a wrong number.
     <span class="sh-cap-unlocks">unlocks</span>
     <div class="sh-cap-chips"><span class="sh-cap-chip">surface</span><span class="sh-cap-chip">evaluate surface</span></div>
   </div>
-  <div class="sh-cap sh-cap--auto">
-    <div class="sh-cap-top"><span class="sh-cap-name">Save / load</span><span class="sh-cap-tag">automatic</span></div>
-    <span class="sh-cap-by">works for free via the runner checkpoint — nothing to implement</span>
-    <span class="sh-cap-unlocks">unlocks</span>
-    <div class="sh-cap-chips"><span class="sh-cap-chip">STPPEstimator.load()</span><span class="sh-cap-chip">re-evaluation from disk</span></div>
-  </div>
 </div>
+
+Save/load and re-evaluation from disk come for free through the runner — there is
+no capability to declare.
 
 ## Declaring in EventModel
 

--- a/docs/extend/capabilities.md
+++ b/docs/extend/capabilities.md
@@ -18,7 +18,7 @@ Skip it → those metrics report a clean skip, never a wrong number.
     <div class="sh-cap-top"><span class="sh-cap-name">Bounded NLL</span><span class="sh-cap-tag">bound</span></div>
     <span class="sh-cap-by">declared by <code>log_prob()</code> returning a surrogate (score-matching, ELBO)</span>
     <span class="sh-cap-unlocks">unlocks</span>
-    <div class="sh-cap-chips"><span class="sh-cap-chip">nll tables · flagged approximate</span></div>
+    <div class="sh-cap-chips"><span class="sh-cap-chip">nll tables · flagged non-exact</span></div>
   </div>
   <div class="sh-cap sh-cap--optional">
     <div class="sh-cap-top"><span class="sh-cap-name">Next-event sampling</span><span class="sh-cap-tag">optional</span></div>

--- a/docs/extend/overview.md
+++ b/docs/extend/overview.md
@@ -2,7 +2,7 @@
 
 Every model in Seahorse has the **same shape**. Express your freshly built STPP
 model that way once, and it plugs into the entire harness — training, multi-seed
-benchmarks, every metric profile, sampling, and save/load — with no other wiring.
+benchmarks, every metric profile, and sampling — with no other wiring.
 
 <div class="sh-ext-contract" markdown="0">
   <span class="sh-ext-wrap">UnifiedSTPP</span>
@@ -26,7 +26,6 @@ benchmarks, every metric profile, sampling, and save/load — with no other wiri
     <span class="sh-ext-pill">bench · multi-seed</span>
     <span class="sh-ext-pill">evaluate · all profiles</span>
     <span class="sh-ext-pill">predict_next</span>
-    <span class="sh-ext-pill">save / load</span>
     <span class="sh-ext-pill">CLI + Python API</span>
   </div>
 </div>

--- a/docs/extend/overview.md
+++ b/docs/extend/overview.md
@@ -1,41 +1,116 @@
-# Extension Overview
+# Bring your model to Seahorse
 
-Seahorse is designed to be extended. The three main extension points are:
+Every model in Seahorse has the **same shape**. Express your freshly built STPP
+model that way once, and it plugs into the entire harness — training, multi-seed
+benchmarks, every metric profile, sampling, and save/load — with no other wiring.
 
-| What to extend | How |
-| --- | --- |
-| **New model family** | Add a `ModelFamilyConfig`, register it, optionally add a `PresetDescriptor` |
-| **Existing PyTorch model** | Wrap it as a `StateModel` / `EventModel` pair |
-| **New dataset** | Format as JSONL splits; optionally publish to HuggingFace |
+<div class="sh-ext-contract" markdown="0">
+  <span class="sh-ext-wrap">UnifiedSTPP</span>
+  <div class="sh-ext-boxes">
+    <div class="sh-ext-mod sh-ext-mod--state">
+      <span class="sh-ext-mod-name">StateModel</span>
+      <span class="sh-ext-mod-flow">event history → hidden state</span>
+      <span class="sh-ext-mod-api"><code>encode</code><code>evolve</code></span>
+    </div>
+    <span class="sh-ext-join" aria-hidden="true">→</span>
+    <div class="sh-ext-mod sh-ext-mod--event">
+      <span class="sh-ext-mod-name">EventModel</span>
+      <span class="sh-ext-mod-flow">hidden state → log-probability</span>
+      <span class="sh-ext-mod-api"><code>log_prob</code><code>sample_next</code><code>intensity_grid</code></span>
+    </div>
+  </div>
+  <span class="sh-ext-down" aria-hidden="true">▼</span>
+  <div class="sh-ext-out">
+    <span class="sh-ext-out-k">you get, for free</span>
+    <span class="sh-ext-pill">fit</span>
+    <span class="sh-ext-pill">bench · multi-seed</span>
+    <span class="sh-ext-pill">evaluate · all profiles</span>
+    <span class="sh-ext-pill">predict_next</span>
+    <span class="sh-ext-pill">save / load</span>
+    <span class="sh-ext-pill">CLI + Python API</span>
+  </div>
+</div>
 
-## Architecture Recap
+Your model is comparable to every baseline by construction: the same data
+contract, the same normalization, the same metric definitions apply the moment
+it is registered.
 
-Every model in Seahorse is a `UnifiedSTPP(state_model, event_model, *, hidden_dim)`. The event history flows through:
+## Four steps from `nn.Module` to benchmarked
 
-```
-history → StateModel.encode() → StateModel.evolve() → EventModel.log_prob() → NLL
-```
+<ol class="sh-ext-steps" markdown="0">
+  <li class="sh-ext-step">
+    <span class="sh-ext-num">1</span>
+    <div class="sh-ext-step-body">
+      <span class="sh-ext-step-title">Wrap your model as two parts</span>
+      <p>Split it into a <strong>StateModel</strong> (encodes history into a hidden state) and an <strong>EventModel</strong> (turns that state into a log-likelihood). Both are plain <code>nn.Module</code>s.</p>
+      <code class="sh-ext-code">class MyEventModel(nn.Module): def log_prob(self, times, locs, state, mask): ...</code>
+      <a class="sh-ext-more" href="../wrap/">Wrap an existing model →</a>
+    </div>
+  </li>
+  <li class="sh-ext-step">
+    <span class="sh-ext-num">2</span>
+    <div class="sh-ext-step-body">
+      <span class="sh-ext-step-title">Wire them in a config</span>
+      <p>A <strong>ModelFamilyConfig</strong> owns the build-time parameters and returns a wired <code>UnifiedSTPP</code> from <code>build_model()</code>.</p>
+      <code class="sh-ext-code">def build_model(self): return UnifiedSTPP(state, event, hidden_dim=self.hidden_dim)</code>
+      <a class="sh-ext-more" href="../preset/">Register a preset →</a>
+    </div>
+  </li>
+  <li class="sh-ext-step">
+    <span class="sh-ext-num">3</span>
+    <div class="sh-ext-step-body">
+      <span class="sh-ext-step-title">Register a preset name</span>
+      <p>One decorator makes your model resolve through <code>fit</code>, <code>bench</code>, <code>evaluate</code>, and the Python API — no import-path changes anywhere else.</p>
+      <code class="sh-ext-code">@ConfigRegistry.register("my_preset")</code>
+      <a class="sh-ext-more" href="../../adding-a-model/">Full checklist →</a>
+    </div>
+  </li>
+  <li class="sh-ext-step">
+    <span class="sh-ext-num">4</span>
+    <div class="sh-ext-step-body">
+      <span class="sh-ext-step-title">Declare what it can do</span>
+      <p>The methods you implement decide which metrics run. An unimplemented capability is reported as a clean skip — never a silent wrong number.</p>
+      <code class="sh-ext-code">def sample_next(self, state, t_last, n_samples=1): ...  # unlocks predictive metrics</code>
+      <a class="sh-ext-more" href="../capabilities/">Declare capabilities →</a>
+    </div>
+  </li>
+</ol>
 
-You implement a `StateModel` (history encoder + state evolution) and an `EventModel` (spatial and temporal decoder). A `ModelFamilyConfig` dataclass wires them together and registers the preset.
+!!! tip "Then test and ship"
+    Run a tiny one-epoch fit, an `evaluate`, and a save/load round-trip before
+    adding the preset to benchmark examples. The
+    [Testing Checklist](testing.md) is the short list to clear.
 
-## Extension Pages
+## Pick your path
 
-| Page | What it covers |
-| --- | --- |
-| [Add a Model](../adding-a-model.md) | End-to-end checklist for a new preset |
-| [Wrap an Existing Model](wrap.md) | Adapter pattern for importing a PyTorch model |
-| [Register a Preset](preset.md) | Config registry, YAML defaults, and CLI wiring |
-| [Declare Capabilities](capabilities.md) | Which evaluation paths your model supports |
-| [Testing Checklist](testing.md) | Minimal test suite before adding to benchmarks |
+<div class="sh-ext-paths" markdown="0">
+  <a class="sh-ext-path" href="../wrap/">
+    <span class="sh-ext-path-when">I already have a PyTorch model</span>
+    <span class="sh-ext-path-title">Wrap an existing model</span>
+    <span class="sh-ext-path-desc">The StateModel / EventModel adapter pattern, with minimal working stubs.</span>
+    <span class="sh-ext-path-go" aria-hidden="true">→</span>
+  </a>
+  <a class="sh-ext-path" href="../../adding-a-model/">
+    <span class="sh-ext-path-when">I'm building a new family from scratch</span>
+    <span class="sh-ext-path-title">Add a model</span>
+    <span class="sh-ext-path-desc">The end-to-end checklist, from components to a bundled preset.</span>
+    <span class="sh-ext-path-go" aria-hidden="true">→</span>
+  </a>
+  <a class="sh-ext-path" href="../preset/">
+    <span class="sh-ext-path-when">My components are ready to expose</span>
+    <span class="sh-ext-path-title">Register a preset</span>
+    <span class="sh-ext-path-desc">Config registry, YAML defaults, and CLI + Python API wiring.</span>
+    <span class="sh-ext-path-go" aria-hidden="true">→</span>
+  </a>
+  <a class="sh-ext-path" href="../capabilities/">
+    <span class="sh-ext-path-when">I'm deciding which metrics apply</span>
+    <span class="sh-ext-path-title">Declare capabilities</span>
+    <span class="sh-ext-path-desc">Map implemented methods to evaluation profiles and exact-vs-approximate NLL.</span>
+    <span class="sh-ext-path-go" aria-hidden="true">→</span>
+  </a>
+</div>
 
-## When to Use Each Page
+## See also
 
-- **New model from scratch**: read [Add a Model](../adding-a-model.md), then [Register a Preset](preset.md).
-- **Wrapping an existing architecture**: start with [Wrap an Existing Model](wrap.md).
-- **Adding sampling or surface support to an existing model**: read [Declare Capabilities](capabilities.md).
-- **Checking your implementation before benchmarking**: run the [Testing Checklist](testing.md).
-
-## See Also
-
-- [Architecture](../architecture.md) — full model layer documentation.
-- [Model Capability Matrix](../model-capability-matrix.md) — what capabilities each preset declares.
+- [Architecture](../architecture.md) — the full model-layer documentation.
+- [Model Capability Matrix](../model-capability-matrix.md) — what each shipped preset declares.

--- a/docs/extend/preset.md
+++ b/docs/extend/preset.md
@@ -1,6 +1,26 @@
 # Register a Preset
 
-A **preset** is a named entry in the config registry. Once registered, it is usable with `fit`, `bench`, `evaluate`, and the Python API without any additional wiring.
+A **preset** is a named entry in the config registry — and that registry is the
+quiet trick that makes Seahorse composable. You register your model **once**, and
+every entry point resolves it by name through the same lookup. No import-path
+changes, no per-command wiring.
+
+<div class="sh-hub" markdown="0">
+  <div class="sh-hub-center">
+    <span class="sh-hub-k">register once</span>
+    <code class="sh-hub-token">@ConfigRegistry.register("my_preset")</code>
+  </div>
+  <span class="sh-hub-fan" aria-hidden="true"></span>
+  <div class="sh-hub-spokes">
+    <span class="sh-hub-spoke">fit</span>
+    <span class="sh-hub-spoke">bench</span>
+    <span class="sh-hub-spoke">evaluate</span>
+    <span class="sh-hub-spoke">predict_next</span>
+    <span class="sh-hub-spoke">CLI&nbsp;·&nbsp;--preset my_preset</span>
+    <span class="sh-hub-spoke">STPPEstimator("my_preset")</span>
+  </div>
+  <span class="sh-hub-cap">One name, reachable everywhere. The registry is the single source every entry point shares — so one decorator is the only wiring you write.</span>
+</div>
 
 ## Step 1: Create a ModelFamilyConfig
 

--- a/docs/extend/wrap.md
+++ b/docs/extend/wrap.md
@@ -1,19 +1,74 @@
 # Wrap an Existing Model
 
-If you have an existing PyTorch STPP model and want to register it as a Seahorse preset, the adapter pattern requires implementing two classes: a `StateModel` and an `EventModel`.
+Have a PyTorch STPP model already? You expose it to Seahorse by splitting it into
+two `nn.Module` adapters — a **StateModel** and an **EventModel** — that
+`UnifiedSTPP` drives. This page shows how a batch of events flows through them,
+what each part owns, and where an optional **PresetDescriptor** fits.
 
-## The UnifiedSTPP Contract
+## How a batch flows through your model
 
-```
-UnifiedSTPP(state_model, event_model, *, hidden_dim)
-```
+A padded batch of sequences enters at the top; each component's method transforms
+it into the next shape, ending in the per-event likelihood Seahorse trains on.
 
-| Component | Responsibility |
-| --- | --- |
-| `StateModel` | Encodes event history into a hidden state; evolves state to a query time |
-| `EventModel` | Computes `log_prob(event | state)` and optionally samples next events |
+<div class="sh-flow" markdown="0">
+  <div class="sh-flow-node sh-flow-node--io">
+    <span class="sh-flow-shape">(B,T) times · (B,T,2) locations · (B,T) mask</span>
+    <span class="sh-flow-note">a padded batch of event sequences</span>
+  </div>
+  <div class="sh-flow-edge sh-flow-edge--state"><span class="sh-flow-call">StateModel.encode()</span></div>
+  <div class="sh-flow-node">
+    <span class="sh-flow-shape">(B, T, H) hidden</span>
+    <span class="sh-flow-note">one hidden vector per observed event</span>
+  </div>
+  <div class="sh-flow-edge sh-flow-edge--state"><span class="sh-flow-call">StateModel.evolve(query_times)</span></div>
+  <div class="sh-flow-node">
+    <span class="sh-flow-shape">(B, T_q, H) state</span>
+    <span class="sh-flow-note">state carried forward to each query time</span>
+  </div>
+  <div class="sh-flow-edge sh-flow-edge--event"><span class="sh-flow-call">EventModel.log_prob(times, locs, state, mask)</span></div>
+  <div class="sh-flow-node sh-flow-node--io sh-flow-node--out">
+    <span class="sh-flow-shape">(B, T) per-event log-likelihood</span>
+    <span class="sh-flow-note">summed over real events → the NLL Seahorse trains and scores</span>
+  </div>
+</div>
 
-Both are `nn.Module` subclasses. The full API is defined in `seahorse/models/unified_model.py`.
+## What each part owns
+
+<div class="sh-comp-grid" markdown="0">
+  <div class="sh-comp sh-comp--state">
+    <span class="sh-comp-tag">required</span>
+    <span class="sh-comp-name">StateModel</span>
+    <span class="sh-comp-role">Turns raw event history into a state vector.</span>
+    <div class="sh-comp-methods">
+      <div class="sh-comp-m"><code>encode(times, locs, mask)</code><span>→ (B, T, H) hidden</span></div>
+      <div class="sh-comp-m"><code>evolve(hidden, query_times)</code><span>→ (B, T_q, H) state</span></div>
+    </div>
+    <span class="sh-comp-where">your <code>StateModel</code> nn.Module</span>
+  </div>
+  <div class="sh-comp sh-comp--event">
+    <span class="sh-comp-tag">required</span>
+    <span class="sh-comp-name">EventModel</span>
+    <span class="sh-comp-role">Scores events under the state — the likelihood, plus optional generation.</span>
+    <div class="sh-comp-methods">
+      <div class="sh-comp-m"><code>log_prob(times, locs, state, mask)</code><span>→ (B, T) · required</span></div>
+      <div class="sh-comp-m"><code>sample_next(state, t_last)</code><span>→ next events · optional</span></div>
+      <div class="sh-comp-m"><code>intensity_grid(state, t, s)</code><span>→ density · optional</span></div>
+    </div>
+    <span class="sh-comp-where">your <code>EventModel</code> nn.Module</span>
+  </div>
+  <div class="sh-comp sh-comp--descriptor">
+    <span class="sh-comp-tag sh-comp-tag--opt">optional</span>
+    <span class="sh-comp-name">PresetDescriptor</span>
+    <span class="sh-comp-role">Injects data-derived setup before the model is built — bounding box, coordinate stats, device fallback.</span>
+    <div class="sh-comp-methods">
+      <div class="sh-comp-m"><code>data_init_overrides(dm)</code><span>→ dict merged into the build</span></div>
+    </div>
+    <span class="sh-comp-where">runs once before <code>build_model()</code>, given the fitted data module</span>
+  </div>
+</div>
+
+`UnifiedSTPP(state_model, event_model, *, hidden_dim)` is the wiring that ties the
+two modules together; the full API lives in `seahorse/models/unified_model.py`.
 
 ## Minimal StateModel Adapter
 

--- a/docs/extend/wrap.md
+++ b/docs/extend/wrap.md
@@ -32,6 +32,9 @@ it into the next shape, ending in the per-event likelihood Seahorse trains on.
   </div>
 </div>
 
+Shapes: **B** sequences per batch, **T** events per sequence, **T_q** query
+times, and **H** = `hidden_dim`.
+
 ## What each part owns
 
 <div class="sh-comp-grid" markdown="0">

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ streaming event data.
   <span class="sh-home-desc">Fit, evaluate, and sample from any registered model through a consistent Python API.</span>
   <span class="sh-home-foot">Python API <span class="sh-home-arrow" aria-hidden="true">→</span></span>
 </a>
-<a class="sh-home-card" href="examples/run-a-small-benchmark/">
+<a class="sh-home-card" href="benchmarks/">
   <span class="sh-home-top"><span class="sh-home-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M22 21H2V3h2v16h2v-2h4v2h2v-3h4v3h2v-2h4zm-4-7h4v2h-4zm-6-8h4v3h-4zm4 9h-4v-5h4zM6 10h4v2H6zm4 6H6v-3h4z"/></svg></span><span class="sh-home-title">Run a Benchmark</span></span>
   <code class="sh-home-handle">python -m seahorse bench</code>
   <span class="sh-home-desc">Compare presets across datasets and seeds from one CLI command with saved, reproducible artifacts.</span>

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,43 +15,31 @@ execution, Ray Tune hyper-parameter optimisation, and version-controlled run
 artifacts to support rapid prototyping and reproducible benchmarking on
 streaming event data.
 
-<div class="grid cards hero-cards" markdown>
-
--   :material-play-circle:{ .lg .middle } **Run One Model**
-
-    ---
-
-    Fit, evaluate, and sample from any registered model through a consistent
-    Python API.
-
-    [:octicons-arrow-right-24: Python API](python-api.md)
-
--   :material-chart-bar-stacked:{ .lg .middle } **Run a Benchmark**
-
-    ---
-
-    Compare presets across datasets and seeds from one CLI command with saved,
-    reproducible artifacts.
-
-    [:octicons-arrow-right-24: Run A Benchmark](examples/run-a-small-benchmark.md)
-
--   :material-magnify:{ .lg .middle } **Evaluate Results**
-
-    ---
-
-    Run metric profiles — likelihood, predictive, surface — on any saved run directory.
-
-    [:octicons-arrow-right-24: Evaluation Guide](evaluation.md)
-
--   :material-plus-box-outline:{ .lg .middle } **Add Your Model**
-
-    ---
-
-    Register a preset and your model works with `fit`, `bench`, and the metric
-    profiles without changing import paths.
-
-    [:octicons-arrow-right-24: Developer Guide](adding-a-model.md)
-
+<div class="sh-home-grid" markdown="0">
+<a class="sh-home-card sh-home-card--primary" href="python-api/">
+  <span class="sh-home-top"><span class="sh-home-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M10 16.5v-9l6 4.5M12 2A10 10 0 0 0 2 12a10 10 0 0 0 10 10 10 10 0 0 0 10-10A10 10 0 0 0 12 2"/></svg></span><span class="sh-home-title">Run One Model</span></span>
+  <code class="sh-home-handle">model.fit(train, val, test)</code>
+  <span class="sh-home-desc">Fit, evaluate, and sample from any registered model through a consistent Python API.</span>
+  <span class="sh-home-foot">Python API <span class="sh-home-arrow" aria-hidden="true">→</span></span>
+</a>
+<a class="sh-home-card" href="examples/run-a-small-benchmark/">
+  <span class="sh-home-top"><span class="sh-home-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M22 21H2V3h2v16h2v-2h4v2h2v-3h4v3h2v-2h4zm-4-7h4v2h-4zm-6-8h4v3h-4zm4 9h-4v-5h4zM6 10h4v2H6zm4 6H6v-3h4z"/></svg></span><span class="sh-home-title">Run a Benchmark</span></span>
+  <code class="sh-home-handle">python -m seahorse bench</code>
+  <span class="sh-home-desc">Compare presets across datasets and seeds from one CLI command with saved, reproducible artifacts.</span>
+  <span class="sh-home-foot">Run a Benchmark <span class="sh-home-arrow" aria-hidden="true">→</span></span>
+</a>
+<a class="sh-home-card" href="evaluation/">
+  <span class="sh-home-top"><span class="sh-home-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9.5 3A6.5 6.5 0 0 1 16 9.5c0 1.61-.59 3.09-1.56 4.23l.27.27h.79l5 5-1.5 1.5-5-5v-.79l-.27-.27A6.52 6.52 0 0 1 9.5 16 6.5 6.5 0 0 1 3 9.5 6.5 6.5 0 0 1 9.5 3m0 2C7 5 5 7 5 9.5S7 14 9.5 14 14 12 14 9.5 12 5 9.5 5"/></svg></span><span class="sh-home-title">Evaluate Results</span></span>
+  <code class="sh-home-handle">model.evaluate(test)</code>
+  <span class="sh-home-desc">Run metric profiles — likelihood, predictive, surface — on any saved run directory.</span>
+  <span class="sh-home-foot">Evaluation Guide <span class="sh-home-arrow" aria-hidden="true">→</span></span>
+</a>
+<a class="sh-home-card" href="adding-a-model/">
+  <span class="sh-home-top"><span class="sh-home-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M19 19V5H5v14zm0-16a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2zm-8 4h2v4h4v2h-4v4h-2v-4H7v-2h4z"/></svg></span><span class="sh-home-title">Add Your Model</span></span>
+  <code class="sh-home-handle">@ConfigRegistry.register(...)</code>
+  <span class="sh-home-desc">Register a preset and your model works with fit, bench, and the metric profiles without changing import paths.</span>
+  <span class="sh-home-foot">Developer Guide <span class="sh-home-arrow" aria-hidden="true">→</span></span>
+</a>
 </div>
 
 ## What Seahorse Provides

--- a/docs/learn/evaluation-semantics.md
+++ b/docs/learn/evaluation-semantics.md
@@ -21,10 +21,10 @@ This is the value stored in `RunResult.test_nll` and reported in benchmark table
 | NLL type | What it means | Families |
 | --- | --- | --- |
 | **Exact** | True log-likelihood of the point process | `auto_stpp`, `deep_stpp`, `nsmpp`, `njsde`, `neural_*`, factorized families |
-| **Approximate (score-matching)** | Score-matching objective — not a valid log-likelihood | `smash` |
-| **Approximate (ELBO)** | Evidence lower bound — not a valid log-likelihood | `diffusion_stpp` |
+| **Approximate (score-matching)** | Score-matching surrogate for the log-likelihood | `smash` |
+| **Approximate (ELBO)** | Evidence lower bound on the log-likelihood | `diffusion_stpp` |
 
-Exact and approximate NLL are **not directly comparable**. Always check the [Model Capability Matrix](../model-capability-matrix.md) before including approximate families in benchmark tables.
+Exact and approximate NLL measure likelihood differently; the [Model Capability Matrix](../model-capability-matrix.md) lists which kind each preset reports.
 
 ## Normalization and Comparability
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
       - Evaluation Semantics: learn/evaluation-semantics.md
       - Reproduce Paper Results: paper-reproduction.md
       - FAQ / Common Errors: learn/faq.md
+      - Cite Seahorse: cite.md
 
 markdown_extensions:
   - attr_list

--- a/overrides/partials/feedback.html
+++ b/overrides/partials/feedback.html
@@ -37,14 +37,19 @@
     <div class="sh-feedback">
       <span class="sh-feedback__prompt">Was this page helpful?</span>
       <button class="sh-feedback__btn" type="button"
-        onclick="this.closest('[data-sh-feedback]').setAttribute('data-sh-feedback','answered')">
+        onclick="this.closest('[data-sh-feedback]').setAttribute('data-sh-feedback','yes')">
         Yes
       </button>
       <button class="sh-feedback__btn" type="button"
-        onclick="this.closest('[data-sh-feedback]').setAttribute('data-sh-feedback','answered')">
+        onclick="this.closest('[data-sh-feedback]').setAttribute('data-sh-feedback','no')">
         No
       </button>
-      <span class="sh-feedback__thanks">Thanks for the feedback.</span>
+      <span class="sh-feedback__yes">
+        Glad it helped — a <a href="{{ config.repo_url }}" target="_blank" rel="noopener noreferrer">&#11088; star on GitHub</a> helps other researchers find Seahorse, and here is <a href="{{ 'cite/' | url }}">how to cite it</a>.
+      </span>
+      <span class="sh-feedback__no">
+        Sorry that missed — <a href="{{ config.repo_url }}/issues/new?labels=documentation&amp;template=doc-feedback.md&amp;title=Docs+feedback%3A+{{ page.title | urlencode }}" target="_blank" rel="noopener noreferrer">tell us what's missing</a>.
+      </span>
     </div>
   {% endif %}
 

--- a/seahorse/api/model_class_map.py
+++ b/seahorse/api/model_class_map.py
@@ -21,6 +21,7 @@ FRIENDLY_TO_PRESET: dict[str, str] = {
     "NeuralJumpCNF": "neural_jumpcnf",
     "NeuralAttnCNF": "neural_attncnf",
     "NeuralCondGMM": "neural_cond_gmm",
+    "NJSDE": "njsde",
     "DeepSTPP": "deep_stpp",
     "AutoSTPP": "auto_stpp",
     "SMASH": "smash",

--- a/seahorse/data/hub.py
+++ b/seahorse/data/hub.py
@@ -14,6 +14,28 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 _DEFAULT_HF_DATASET_REPO = os.environ.get("SEAHORSE_HF_DATASET_REPO")
 _SPLIT_NAMES = ("train", "val", "test")
 
+# Consolidated Hugging Face organization holding the ready-to-use datasets.
+_SEAHORSE_HF_ORG = "seahorse-stpp"
+
+# Short, friendly names for the curated real-world datasets, each mapping to its
+# repo under the seahorse-stpp org. These let users pass `--dataset citibike`
+# instead of the full `seahorse-stpp/citibike-stpp` id.
+_REAL_WORLD_DATASETS = {
+    "citibike": "citibike-stpp",
+    "uber_pickups": "uber_pickups_nyc_stpp",
+    "us_accidents": "us_accidents_stpp",
+    "chicago_crime": "chicago_crime_stpp",
+    "la_crime": "la_crime_stpp",
+    "gtd": "gtd_stpp",
+    "austin_311": "austin_311_stpp",
+    "earthquakes": "earthquakes-stpp",
+    "us_wildfires": "us_wildfires_stpp",
+    "covid": "covid-stpp",
+    "gowalla": "gowalla_checkins_stpp",
+    "brightkite": "brightkite_checkins_stpp",
+    "bold5000": "bold5000-stpp",
+}
+
 
 @dataclass(frozen=True)
 class CuratedDatasetSpec:
@@ -100,6 +122,14 @@ def _build_catalog() -> dict[str, CuratedDatasetSpec]:
                 + [f"topology_T{i}" for i in range(6)]
             ),
         )
+    )
+
+    specs.extend(
+        CuratedDatasetSpec(
+            name=name,
+            repo_id=f"{_SEAHORSE_HF_ORG}/{repo_leaf}",
+        )
+        for name, repo_leaf in _REAL_WORLD_DATASETS.items()
     )
 
     catalog: dict[str, CuratedDatasetSpec] = {}

--- a/tests/test_hf_dataset_smoke.py
+++ b/tests/test_hf_dataset_smoke.py
@@ -12,7 +12,7 @@ from seahorse.config.schema import STPPConfig
 
 
 HF_SMOKE_ENABLED = os.environ.get("SEAHORSE_RUN_HF_SMOKE") == "1"
-HF_SMOKE_DATASET = os.environ.get("SEAHORSE_HF_SMOKE_DATASET", "I5m41L/austin_311_stpp")
+HF_SMOKE_DATASET = os.environ.get("SEAHORSE_HF_SMOKE_DATASET", "seahorse-stpp/austin_311_stpp")
 HF_SMOKE_DATASET_ID = HF_SMOKE_DATASET.rstrip("/").split("/")[-1]
 
 


### PR DESCRIPTION
Consolidates the documentation overhaul and the dataset-inclusion work onto `main`.

## Documentation
- **Homepage** restyled to the dataset-card system; action cards point to the right entry pages.
- **Dataset catalog** rebuilt as a domain-organized gallery (13 datasets), credits the HawkesNest synthetic suite, frames BOLD5000 as the supported non-2D case.
- **Extend / Wrap / Capabilities** rebuilt into a visual "bring your model" hub (capability map, data-flow anatomy, register hub).
- **Benchmark overview** rebuilt into a visual hub: a campaign-matrix signature `(preset × dataset × seed)`, the one command, route cards, and a one-paragraph comparability contract.
- Neutral, non-defensive wording for exact vs. approximate (bound) NLL across compare / capabilities / evaluation-semantics.

## Datasets (the 9 new + trio, now 13)
- All 13 datasets live under the consolidated `seahorse-stpp` HF org.
- **Short names**: `--dataset citibike` / `load_dataset("citibike")` now resolve for every dataset (covid, earthquakes, gtd, gowalla, …); the full `seahorse-stpp/<id>` still works.
- Docs updated to use the short names.

## Small code changes
- `seahorse/data/hub.py`: short-name → `seahorse-stpp/<id>` routing for the 13 datasets.
- `seahorse/api/model_class_map.py`: add `NJSDE` friendly class so the presets table references a real importable name.
- `tests/test_hf_dataset_smoke.py`: default dataset points at `seahorse-stpp` (was the old `I5m41L` account).

Strict `mkdocs build` passes; dataset/hub unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)