### PR TITLE
release: Apache-2.0, packaging metadata, CITATION.cff, config fail-fast (Phase 0)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,39 @@
+cff-version: 1.2.0
+message: "If you use Seahorse in your research, please cite the software (and the accompanying paper once it is public)."
+title: "Seahorse: Unified Benchmarking for Spatio-Temporal Point Processes"
+abstract: "A modular, research-grade framework for end-to-end development, training, and evaluation of spatio-temporal point-process (STPP) models."
+type: software
+authors:
+  - family-names: Aalaila
+    given-names: Yahya
+    # orcid: "https://orcid.org/0000-0000-0000-0000"  # TODO: add ORCID
+  - family-names: Großmann
+    given-names: Gerrit
+    # orcid: "https://orcid.org/0000-0000-0000-0000"  # TODO: add ORCID
+  - family-names: Vollmer
+    given-names: Sebastian
+    # orcid: "https://orcid.org/0000-0000-0000-0000"  # TODO: add ORCID
+version: 0.1.0
+license: Apache-2.0
+repository-code: "https://github.com/YahyaAalaila/seahorse"
+url: "https://yahyaaalaila.github.io/seahorse/"
+keywords:
+  - spatio-temporal point process
+  - Hawkes process
+  - neural STPP
+  - benchmarking
+  - PyTorch
+# doi: "10.5281/zenodo.XXXXXXX"   # TODO: add the reserved Zenodo DOI before release (Phase 3)
+# date-released: 2026-XX-XX        # TODO: set to the v0.1.0 release date
+preferred-citation:
+  type: article
+  title: "TODO: paper title"
+  authors:
+    - family-names: Aalaila
+      given-names: Yahya
+    - family-names: Großmann
+      given-names: Gerrit
+    - family-names: Vollmer
+      given-names: Sebastian
+  year: 2026
+  # notes: arXiv identifier to be added once the preprint is public (Phase 5).

--- a/LICENSE
+++ b/LICENSE
@@ -1,22 +1,201 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2026
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Deutsches Forschungszentrum für Künstliche Intelligenz GmbH (DFKI)
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+recursive-include seahorse/configs *.yaml
+include LICENSE
+include NOTICE
+include README.md

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,6 @@
+Seahorse (seahorse-stpp)
+Copyright 2026 Deutsches Forschungszentrum für Künstliche Intelligenz GmbH (DFKI)
+
+This product includes software developed with support from the German Federal
+Ministry of Education and Research (Bundesministerium für Bildung und Forschung,
+BMBF) under Grant No. 01W23005 (project EVENTFUL).

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Documentation: https://yahyaaalaila.github.io/seahorse/
 [![Last Commit](https://img.shields.io/github/last-commit/YahyaAalaila/seahorse)](https://github.com/YahyaAalaila/seahorse/commits)
 [![Branch](https://img.shields.io/badge/branch-latest-brightgreen)](https://github.com/YahyaAalaila/seahorse)
 [![Issues](https://img.shields.io/github/issues/YahyaAalaila/seahorse)](https://github.com/YahyaAalaila/seahorse/issues)
-[![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
+[![License](https://img.shields.io/badge/license-Apache_2.0-blue)](LICENSE)
 
-[![Python](https://img.shields.io/badge/python-3.9%2B-blue?logo=python&logoColor=white)](https://www.python.org/)
+[![Python](https://img.shields.io/badge/python-3.10%2B-blue?logo=python&logoColor=white)](https://www.python.org/)
 [![PyTorch](https://img.shields.io/badge/pytorch-2.2%2B-orange?logo=pytorch&logoColor=white)](https://pytorch.org/)
 [![Lightning](https://img.shields.io/badge/lightning-2.2%2B-792ee5)](https://lightning.ai/)
 [![Ray Tune](https://img.shields.io/badge/ray__tune-2.9%2B-028CF0)](https://docs.ray.io/en/latest/tune/)
@@ -211,25 +211,34 @@ python -m seahorse tune \
 
 ## 📝 Citation [[Back&nbsp;to&nbsp;Top](#top)]
 
-If Seahorse supports your work, cite the repository:
+If Seahorse supports your work, please cite it. The accompanying paper is in
+preparation; until the preprint is public, cite the software release:
 
 ```bibtex
-@software{aalaila_seahorse,
-  title = {Seahorse: Unified Benchmarking for Spatio-Temporal Point Processes},
-  author = {Aalaila, Yahya},
-  url = {https://github.com/YahyaAalaila/seahorse},
-  license = {MIT}
+@software{seahorse2026,
+  title   = {Seahorse: Unified Benchmarking for Spatio-Temporal Point Processes},
+  author  = {Aalaila, Yahya and Gro{\ss}mann, Gerrit and Vollmer, Sebastian},
+  year    = {2026},
+  version = {0.1.0},
+  url     = {https://github.com/YahyaAalaila/seahorse},
+  license = {Apache-2.0}
 }
 ```
+
+GitHub's **Cite this repository** button (from [`CITATION.cff`](CITATION.cff)) offers the same entry in APA and BibTeX.
 
 ---
 
 ## ⚖️ License [[Back&nbsp;to&nbsp;Top](#top)]
 
-Seahorse is distributed under the **MIT License**. See [LICENSE](LICENSE).
+Seahorse is distributed under the **Apache License 2.0**. See [LICENSE](LICENSE) and [NOTICE](NOTICE).
 
 ---
 
 ## 🙏 Acknowledgment [[Back&nbsp;to&nbsp;Top](#top)]
 
-Seahorse builds on the original implementations of the paper families it wraps. We thank the authors of AutoSTPP, DeepSTPP, NeuralSTPP, NJSDE, DiffusionSTPP, NSMPP, SMASH, THP, and RMTPP for releasing their code.
+**Funding.** The authors received support from the Bundesministerium für Bildung und Forschung (BMBF) under Grant No. 01W23005 for the project EVENTFUL.
+
+**Contributors.** Beyond the authors, we thank Ismail Drief and Raphael Sonabend-Friend for their contributions to the codebase and its early design.
+
+**Upstream implementations.** Seahorse builds on the original implementations of the paper families it wraps. We thank the authors of AutoSTPP, DeepSTPP, NeuralSTPP, NJSDE, DiffusionSTPP, NSMPP, SMASH, THP, and RMTPP for releasing their code.

--- a/docs/cite.md
+++ b/docs/cite.md
@@ -11,11 +11,12 @@ way to support the project — and it helps other researchers find the tooling.
 
 ```bibtex
 @software{seahorse2026,
-  author  = {Aalaila, Yahya and contributors},
+  author  = {Aalaila, Yahya and Gro{\ss}mann, Gerrit and Vollmer, Sebastian},
   title   = {Seahorse: Unified benchmarking for spatio-temporal point processes},
   year    = {2026},
   url     = {https://github.com/YahyaAalaila/seahorse},
-  version = {0.1.0}
+  version = {0.1.0},
+  license = {Apache-2.0}
 }
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,31 @@ version = "0.1.0"
 description = "Seahorse: unified benchmarking for spatio-temporal point-process models"
 readme = "README.md"
 requires-python = ">=3.10"
-license = { text = "MIT" }
-authors = [{ name = "Yahya Aalaila" }]
+license = "Apache-2.0"
+license-files = ["LICENSE", "NOTICE"]
+authors = [
+  { name = "Yahya Aalaila" },
+  { name = "Gerrit Großmann" },
+  { name = "Sebastian Vollmer" },
+]
+keywords = [
+  "spatio-temporal",
+  "point-process",
+  "hawkes",
+  "neural-stpp",
+  "benchmark",
+  "pytorch",
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Science/Research",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
 dependencies = [
   "torch>=2.8.0",
   "pytorch-lightning>=2.3.3",
@@ -45,9 +68,21 @@ all = [
   "seahorse-stpp[runner,hpo,docs]",
 ]
 
+[project.urls]
+Homepage = "https://github.com/YahyaAalaila/seahorse"
+Repository = "https://github.com/YahyaAalaila/seahorse"
+Documentation = "https://yahyaaalaila.github.io/seahorse/"
+Issues = "https://github.com/YahyaAalaila/seahorse/issues"
+
+[project.scripts]
+seahorse = "seahorse.__main__:main"
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["seahorse", "seahorse.*"]
+
+[tool.setuptools.package-data]
+seahorse = ["configs/*.yaml"]
 
 [tool.pytest.ini_options]
 minversion = "8.0"

--- a/seahorse/__init__.py
+++ b/seahorse/__init__.py
@@ -1,5 +1,12 @@
 """Public package exports for Seahorse / ``seahorse-stpp``."""
 
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+try:
+    __version__ = _pkg_version("seahorse-stpp")
+except PackageNotFoundError:  # running from a source tree without an install
+    __version__ = "0.0.0+unknown"
+
 from .config import STPPConfig, DataConfig, ModelConfig, TrainingConfig, LoggingConfig
 from .runner import STPPRunner, RunResult
 from .benchmark import Benchmark, BenchmarkTable
@@ -15,6 +22,7 @@ from .api import (
 globals().update(FRIENDLY_MODEL_CLASSES)
 
 __all__ = [
+    "__version__",
     "STPPConfig",
     "DataConfig",
     "ModelConfig",

--- a/seahorse/config/schema.py
+++ b/seahorse/config/schema.py
@@ -484,10 +484,24 @@ class STPPConfig(BaseModel):
                 if ConfigRegistry.is_registered(preset)
                 else preset
             )
-            yaml_path = Path(__file__).parent.parent / "configs" / f"{source_preset}.yaml"
+            configs_dir = Path(__file__).parent.parent / "configs"
+            yaml_path = configs_dir / f"{source_preset}.yaml"
             if yaml_path.exists():
                 with open(yaml_path) as f:
                     return _yaml_load_compat(f)
+            # Some presets (e.g. the factorized GMM/CNF families) ship no YAML
+            # and build entirely from schema defaults — that is legitimate, but
+            # ONLY when the bundled config directory itself is intact. An empty
+            # or missing directory means the package was built without its YAML
+            # data files (see [tool.setuptools.package-data] in pyproject.toml);
+            # falling back to an empty dict would silently produce a wrong model.
+            if not configs_dir.is_dir() or not any(configs_dir.glob("*.yaml")):
+                raise FileNotFoundError(
+                    f"Bundled Seahorse config directory is missing or empty: {configs_dir}. "
+                    "This indicates a broken installation where the YAML preset data was "
+                    "not packaged. Reinstall a correctly built 'seahorse-stpp' "
+                    "(pip install --force-reinstall seahorse-stpp)."
+                )
             return {"data": {}, "model": {"preset": source_preset}, "training": {}}
         raise ValueError("Either 'preset' or 'config' must be provided.")
 


### PR DESCRIPTION
Phase 0 of the 0.1.0 release — repo prep, no publishing. All reversible until we tag.

## License
- Relicensed **MIT → Apache-2.0** (adds a patent grant; institution-friendly).
- Copyright holder: **DFKI** — ⚠️ **to confirm with DFKI's open-source / tech-transfer office before we publish** (Phase 3 gate). Trivially changeable until then.
- Added `NOTICE` with the DFKI copyright + the BMBF/EVENTFUL funding attribution.

## Packaging (folds in the `release/0.1.0` work)
- `pyproject.toml`: SPDX `license`, `license-files`, 3 authors, classifiers, `project.urls`, `seahorse` console script, keywords, `package-data` for the preset YAMLs.
- `MANIFEST.in`: ship `seahorse/configs/*.yaml` + LICENSE + NOTICE in the sdist.
- `seahorse.__version__` via `importlib.metadata`.
- **Config fail-fast** (`schema.raw_source_dict`): raises on a missing/empty bundled config dir instead of silently returning `{}` — a broken install becomes a loud, actionable error.

## Citation & credit
- `CITATION.cff` with the paper authors (Aalaila, Großmann, Vollmer); ORCID / Zenodo DOI / arXiv left as `TODO` placeholders.
- README: Apache badge + license section, multi-author citation, and an **Acknowledgments** section (BMBF/EVENTFUL funding + contributors Ismail Drief, Raphael Sonabend-Friend).

## Verified
- `uv build` + `twine check` **PASSED** (wheel + sdist).
- Wheel bundles 11 config YAMLs + LICENSE + NOTICE; Metadata-Version 2.4, `License-Expression: Apache-2.0`.
- Strict `mkdocs build` passes; `CITATION.cff` valid.

### Before Phase 3 (publish), still TODO
- Confirm copyright holder with DFKI.
- Fill ORCIDs, reserved Zenodo DOI, arXiv ID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)