### PR TITLE
docs: back-fill Zenodo DOI

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,8 +23,15 @@ keywords:
   - neural STPP
   - benchmarking
   - PyTorch
-# doi: "10.5281/zenodo.XXXXXXX"   # TODO: add the reserved Zenodo DOI before release (Phase 3)
-# date-released: 2026-XX-XX        # TODO: set to the v0.1.0 release date
+doi: "10.5281/zenodo.21078077"
+date-released: 2026-06-30
+identifiers:
+  - type: doi
+    value: "10.5281/zenodo.21078077"
+    description: "Concept DOI (all versions)"
+  - type: doi
+    value: "10.5281/zenodo.21078078"
+    description: "Version DOI (v0.1.0)"
 preferred-citation:
   type: article
   title: "TODO: paper title"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Documentation: https://yahyaaalaila.github.io/seahorse/
 [![Branch](https://img.shields.io/badge/branch-latest-brightgreen)](https://github.com/YahyaAalaila/seahorse)
 [![Issues](https://img.shields.io/github/issues/YahyaAalaila/seahorse)](https://github.com/YahyaAalaila/seahorse/issues)
 [![License](https://img.shields.io/badge/license-Apache_2.0-blue)](LICENSE)
+[![PyPI](https://img.shields.io/pypi/v/seahorse-stpp.svg)](https://pypi.org/project/seahorse-stpp/)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21078077.svg)](https://doi.org/10.5281/zenodo.21078077)
 
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue?logo=python&logoColor=white)](https://www.python.org/)
 [![PyTorch](https://img.shields.io/badge/pytorch-2.2%2B-orange?logo=pytorch&logoColor=white)](https://pytorch.org/)
@@ -220,6 +222,7 @@ preparation; until the preprint is public, cite the software release:
   author  = {Aalaila, Yahya and Gro{\ss}mann, Gerrit and Vollmer, Sebastian},
   year    = {2026},
   version = {0.1.0},
+  doi     = {10.5281/zenodo.21078077},
   url     = {https://github.com/YahyaAalaila/seahorse},
   license = {Apache-2.0}
 }

--- a/docs/cite.md
+++ b/docs/cite.md
@@ -14,11 +14,14 @@ way to support the project — and it helps other researchers find the tooling.
   author  = {Aalaila, Yahya and Gro{\ss}mann, Gerrit and Vollmer, Sebastian},
   title   = {Seahorse: Unified benchmarking for spatio-temporal point processes},
   year    = {2026},
+  doi     = {10.5281/zenodo.21078077},
   url     = {https://github.com/YahyaAalaila/seahorse},
   version = {0.1.0},
   license = {Apache-2.0}
 }
 ```
 
-Once a `CITATION.cff` is published in the repository, GitHub's **Cite this
-repository** button will offer the same entry in APA and BibTeX.
+Every release is archived on Zenodo with a DOI — cite the **concept DOI**
+[10.5281/zenodo.21078077](https://doi.org/10.5281/zenodo.21078077) to reference
+the software across versions. GitHub's **Cite this repository** button (from the
+repository's `CITATION.cff`) offers the same entry in APA and BibTeX.


### PR DESCRIPTION
Adds the Zenodo concept DOI `10.5281/zenodo.21078077` (all-versions) to CITATION.cff (+ version DOI in identifiers), the README (PyPI + DOI badges and citation), and the cite page. Closes out the software-release metadata for 0.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)