### PR TITLE
docs: install from PyPI everywhere (notebooks + guides)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,22 @@ For more detailed guides, check out our documentation:
 - [End-to-End Case Study](https://yahyaaalaila.github.io/seahorse/examples/case-study/)
 - [Predicting with Models](https://yahyaaalaila.github.io/seahorse/run-models/predict/)
 
-**Install**
+**Install** (from PyPI):
+
+```bash
+pip install seahorse-stpp
+```
+
+Optional extras: `pip install "seahorse-stpp[hpo]"` for Ray Tune HPO.
+
+<details>
+<summary>Development install from source</summary>
 
 *macOS / Linux:*
 
 ```bash
 python -m venv .venv && source .venv/bin/activate
-pip install -e .
+pip install -e ".[dev]"
 ```
 
 *Windows:*
@@ -88,8 +97,10 @@ pip install -e .
 ```powershell
 python -m venv .venv
 .\.venv\Scripts\activate
-pip install -e .
+pip install -e ".[dev]"
 ```
+
+</details>
 
 **Python API**
 

--- a/docs/benchmark/tune.md
+++ b/docs/benchmark/tune.md
@@ -3,7 +3,7 @@
 Seahorse uses Ray Tune for HPO. Install the HPO extras before running any tune command:
 
 ```bash
-python -m pip install -e ".[hpo]"
+pip install "seahorse-stpp[hpo]"
 ```
 
 ## CLI: tune a single preset

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -49,7 +49,7 @@ Key options:
 
 ## tune: Search Hyperparameters
 
-Requires HPO dependencies: `python -m pip install -e ".[hpo]"`
+Requires HPO dependencies: `pip install "seahorse-stpp[hpo]"`
 
 ??? example "Show CLI command"
     ```bash

--- a/docs/examples/colabs.md
+++ b/docs/examples/colabs.md
@@ -20,8 +20,7 @@ From the repository root:
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-python -m pip install -e .
-python -m pip install notebook
+python -m pip install seahorse-stpp notebook
 jupyter notebook docs/notebooks/
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,23 +4,25 @@ Two main workflows: one-model Python experiments and reproducible CLI runs.
 
 ## Install
 
-=== "Core"
+=== "PyPI"
 
     ```bash
     python -m venv .venv && source .venv/bin/activate
-    python -m pip install -e .
+    python -m pip install seahorse-stpp
     ```
 
-=== "With dev tools"
+=== "With HPO (Ray Tune)"
 
     ```bash
+    python -m pip install "seahorse-stpp[hpo]"
+    ```
+
+=== "From source (development)"
+
+    ```bash
+    git clone https://github.com/YahyaAalaila/seahorse.git
+    cd seahorse
     python -m pip install -e ".[dev]"
-    ```
-
-=== "With HPO"
-
-    ```bash
-    python -m pip install -e ".[hpo]"
     ```
 
 ## Prepare Data

--- a/docs/learn/faq.md
+++ b/docs/learn/faq.md
@@ -3,10 +3,10 @@
 ## Installation and Setup
 
 **`No module named seahorse`**
-: Install in development mode from the repository root: `python -m pip install -e .`
+: Install Seahorse — `pip install seahorse-stpp` (or `pip install -e .` from a source checkout).
 
 **`No module named ray` or HPO errors**
-: Install HPO dependencies: `python -m pip install -e ".[hpo]"`
+: Install the HPO extras: `pip install "seahorse-stpp[hpo]"`
 
 **`No module named plotly`**
 : `plot_kde_surface` requires Plotly: `python -m pip install plotly`
@@ -67,7 +67,7 @@
 ## Benchmarking
 
 **HPO dependency errors with `--tune`**
-: Remove `--tune` unless you intend to run HPO, or install HPO extras: `python -m pip install -e ".[hpo]"`
+: Remove `--tune` unless you intend to run HPO, or install HPO extras: `pip install "seahorse-stpp[hpo]"`
 
 **Benchmark cells have inconsistent NLL**
 : Check that all presets were run under the same `--normalize` / `--no-normalize` setting. The benchmark contract enforces this when using `bench` directly, but manual `fit` runs do not automatically apply the contract.

--- a/docs/notebooks/01_run_one_model_python_api.ipynb
+++ b/docs/notebooks/01_run_one_model_python_api.ipynb
@@ -4,27 +4,13 @@
    "cell_type": "markdown",
    "id": "f8ff9c43",
    "metadata": {},
-   "source": [
-    "# Run One Model With The Python API\n",
-    "\n",
-    "This notebook creates a small synthetic JSONL dataset, trains `AutoSTPP` and\n",
-    "`PoissonGMM` for one CPU epoch, evaluates them, samples next events, and makes a\n",
-    "small predictive scatter plot.\n",
-    "\n",
-    "It does not require Hugging Face data or a GPU. When opened directly in\n",
-    "Colab, the install cell clones the public repository and installs Seahorse.\n"
-   ]
+   "source": "# Run One Model With The Python API\n\nThis notebook creates a small synthetic JSONL dataset, trains `AutoSTPP` and\n`PoissonGMM` for one CPU epoch, evaluates them, samples next events, and makes a\nsmall predictive scatter plot.\n\nIt does not require Hugging Face data or a GPU. When opened directly in\nColab, the install cell installs Seahorse from PyPI (`pip install seahorse-stpp`)."
   },
   {
    "cell_type": "markdown",
    "id": "cb6f5497",
    "metadata": {},
-   "source": [
-    "## Install/import\n",
-    "\n",
-    "The setup cell is safe to run locally or in a fresh Colab runtime. In Colab,\n",
-    "it clones the public repository if `seahorse` is not already importable.\n"
-   ]
+   "source": "## Install/import\n\nThe setup cell is safe to run locally or in a fresh Colab runtime. In Colab,\nit installs `seahorse-stpp` from PyPI if `seahorse` is not already importable."
   },
   {
    "cell_type": "code",
@@ -39,37 +25,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "import importlib.util\n",
-    "import os\n",
-    "import subprocess\n",
-    "import sys\n",
-    "from pathlib import Path\n",
-    "\n",
-    "REPO_URL = \"https://github.com/YahyaAalaila/seahorse.git\"\n",
-    "REPO_DIR = Path(\"/content/seahorse\")\n",
-    "\n",
-    "if Path.cwd().name == \"notebooks\" and Path.cwd().parent.parent.joinpath(\"pyproject.toml\").exists():\n",
-    "    os.chdir(Path.cwd().parent.parent)\n",
-    "elif Path.cwd().parent.joinpath(\"pyproject.toml\").exists():\n",
-    "    os.chdir(Path.cwd().parent)\n",
-    "\n",
-    "if importlib.util.find_spec(\"seahorse\") is None:\n",
-    "    if not Path(\"pyproject.toml\").exists() and Path(\"/content\").exists():\n",
-    "        if not REPO_DIR.exists():\n",
-    "            subprocess.run([\"git\", \"clone\", \"--depth\", \"1\", REPO_URL, str(REPO_DIR)], check=True)\n",
-    "        os.chdir(REPO_DIR)\n",
-    "\n",
-    "    if not Path(\"pyproject.toml\").exists():\n",
-    "        raise RuntimeError(\"Run from the Seahorse repository root, or open this notebook in Colab with network access.\")\n",
-    "\n",
-    "    %pip install -q -e .\n",
-    "\n",
-    "import matplotlib.pyplot as plt\n",
-    "import numpy as np\n",
-    "\n",
-    "from seahorse import AutoSTPP, PoissonGMM, load_jsonl\n"
-   ]
+   "source": "# Install Seahorse. In Colab or any fresh runtime this pulls the released\n# package from PyPI; if `seahorse` is already importable (e.g. a local dev\n# install), nothing is installed.\nimport importlib.util\n\nif importlib.util.find_spec(\"seahorse\") is None:\n    %pip install -q seahorse-stpp\n\nimport matplotlib.pyplot as plt\nimport numpy as np\n\nfrom seahorse import AutoSTPP, PoissonGMM, load_jsonl"
   },
   {
    "cell_type": "markdown",

--- a/docs/notebooks/02_benchmark_models_cli.ipynb
+++ b/docs/notebooks/02_benchmark_models_cli.ipynb
@@ -4,26 +4,13 @@
    "cell_type": "markdown",
    "id": "919760e9",
    "metadata": {},
-   "source": [
-    "# Benchmark Models With The CLI\n",
-    "\n",
-    "This notebook creates a small local JSONL dataset, runs a small benchmark with\n",
-    "`python -m seahorse bench`, and inspects the resulting output directory.\n",
-    "\n",
-    "It does not require Hugging Face data or a GPU. When opened directly in\n",
-    "Colab, the install cell clones the public repository and installs Seahorse.\n"
-   ]
+   "source": "# Benchmark Models With The CLI\n\nThis notebook creates a small local JSONL dataset, runs a small benchmark with\n`python -m seahorse bench`, and inspects the resulting output directory.\n\nIt does not require Hugging Face data or a GPU. When opened directly in\nColab, the install cell installs Seahorse from PyPI (`pip install seahorse-stpp`)."
   },
   {
    "cell_type": "markdown",
    "id": "bc21fd00",
    "metadata": {},
-   "source": [
-    "## Install/import\n",
-    "\n",
-    "The setup cell is safe to run locally or in a fresh Colab runtime. In Colab,\n",
-    "it clones the public repository if `seahorse` is not already importable.\n"
-   ]
+   "source": "## Install/import\n\nThe setup cell is safe to run locally or in a fresh Colab runtime. In Colab,\nit installs `seahorse-stpp` from PyPI if `seahorse` is not already importable."
   },
   {
    "cell_type": "code",
@@ -38,39 +25,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "import importlib.util\n",
-    "import os\n",
-    "import subprocess\n",
-    "import sys\n",
-    "from pathlib import Path\n",
-    "\n",
-    "REPO_URL = \"https://github.com/YahyaAalaila/seahorse.git\"\n",
-    "REPO_DIR = Path(\"/content/seahorse\")\n",
-    "\n",
-    "if Path.cwd().name == \"notebooks\" and Path.cwd().parent.parent.joinpath(\"pyproject.toml\").exists():\n",
-    "    os.chdir(Path.cwd().parent.parent)\n",
-    "elif Path.cwd().parent.joinpath(\"pyproject.toml\").exists():\n",
-    "    os.chdir(Path.cwd().parent)\n",
-    "\n",
-    "if importlib.util.find_spec(\"seahorse\") is None:\n",
-    "    if not Path(\"pyproject.toml\").exists() and Path(\"/content\").exists():\n",
-    "        if not REPO_DIR.exists():\n",
-    "            subprocess.run([\"git\", \"clone\", \"--depth\", \"1\", REPO_URL, str(REPO_DIR)], check=True)\n",
-    "        os.chdir(REPO_DIR)\n",
-    "\n",
-    "    if not Path(\"pyproject.toml\").exists():\n",
-    "        raise RuntimeError(\"Run from the Seahorse repository root, or open this notebook in Colab with network access.\")\n",
-    "\n",
-    "    %pip install -q -e .\n",
-    "\n",
-    "import json\n",
-    "import shutil\n",
-    "import subprocess\n",
-    "from pathlib import Path\n",
-    "\n",
-    "import pandas as pd\n"
-   ]
+   "source": "# Install Seahorse. In Colab or any fresh runtime this pulls the released\n# package from PyPI; if `seahorse` is already importable (e.g. a local dev\n# install), nothing is installed.\nimport importlib.util\n\nif importlib.util.find_spec(\"seahorse\") is None:\n    %pip install -q seahorse-stpp\n\nimport json\nimport shutil\nimport subprocess\nimport sys\nfrom pathlib import Path\n\nimport pandas as pd"
   },
   {
    "cell_type": "markdown",

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -139,7 +139,7 @@ best_config = model.tune(train, val, n_trials=10, max_epochs=20)
 This uses the existing Ray Tune path. Install HPO dependencies before using it:
 
 ```bash
-python -m pip install -e ".[hpo]"
+pip install "seahorse-stpp[hpo]"
 ```
 
 ## Save And Load


### PR DESCRIPTION
Now that `seahorse-stpp` is on PyPI, the Colab notebooks and install docs use the package instead of the clone + `pip install -e .` hack (the fragile path that caused the original stale-import errors).

- **Notebooks 01 & 02**: setup cell installs `seahorse-stpp` from PyPI when `seahorse` isn't importable; no more `git clone` / editable install.
- **README / getting-started**: lead with `pip install seahorse-stpp` (extras: `[hpo]`); from-source dev install kept for contributors.
- **cli / python-api / tune / faq / colabs**: HPO install via `pip install "seahorse-stpp[hpo]"`.

Strict mkdocs build passes; notebooks validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)