### PR TITLE
docs: cite the paper (arXiv 2607.01022)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -34,7 +34,7 @@ identifiers:
     description: "Version DOI (v0.1.0)"
 preferred-citation:
   type: article
-  title: "TODO: paper title"
+  title: "Seahorse: A Unified Benchmarking Framework for Spatiotemporal Event Modeling"
   authors:
     - family-names: Aalaila
       given-names: Yahya
@@ -46,4 +46,5 @@ preferred-citation:
       given-names: Sebastian
       orcid: "https://orcid.org/0000-0003-2831-1401"
   year: 2026
-  # notes: arXiv identifier to be added once the preprint is public (Phase 5).
+  journal: "arXiv preprint arXiv:2607.01022"
+  url: "https://arxiv.org/abs/2607.01022"

--- a/README.md
+++ b/README.md
@@ -229,8 +229,20 @@ python -m seahorse tune \
 
 ## 📝 Citation [[Back&nbsp;to&nbsp;Top](#top)]
 
-If Seahorse supports your work, please cite it. The accompanying paper is in
-preparation; until the preprint is public, cite the software release:
+If Seahorse supports your work, please cite the paper:
+
+```bibtex
+@misc{aalaila2026seahorse,
+  title         = {Seahorse: A Unified Benchmarking Framework for Spatiotemporal Event Modeling},
+  author        = {Aalaila, Yahya and Gro{\ss}mann, Gerrit and Vollmer, Sebastian},
+  year          = {2026},
+  eprint        = {2607.01022},
+  archivePrefix = {arXiv},
+  primaryClass  = {cs.LG}
+}
+```
+
+To cite the software release specifically, use the Zenodo DOI:
 
 ```bibtex
 @software{seahorse2026,
@@ -244,7 +256,7 @@ preparation; until the preprint is public, cite the software release:
 }
 ```
 
-GitHub's **Cite this repository** button (from [`CITATION.cff`](CITATION.cff)) offers the same entry in APA and BibTeX.
+GitHub's **Cite this repository** button (from [`CITATION.cff`](CITATION.cff)) offers these entries in APA and BibTeX.
 
 ---
 

--- a/docs/cite.md
+++ b/docs/cite.md
@@ -3,9 +3,20 @@
 If Seahorse helped your research, please cite it. A citation is the most direct
 way to support the project — and it helps other researchers find the tooling.
 
-!!! note "Paper coming soon"
-    The Seahorse paper is in preparation. Until the preprint is public, cite the
-    software release below; this page will be updated with the paper reference.
+## Paper
+
+The Seahorse preprint is on [arXiv:2607.01022](https://arxiv.org/abs/2607.01022).
+
+```bibtex
+@misc{aalaila2026seahorse,
+  title         = {Seahorse: A Unified Benchmarking Framework for Spatiotemporal Event Modeling},
+  author        = {Aalaila, Yahya and Gro{\ss}mann, Gerrit and Vollmer, Sebastian},
+  year          = {2026},
+  eprint        = {2607.01022},
+  archivePrefix = {arXiv},
+  primaryClass  = {cs.LG}
+}
+```
 
 ## Software
 


### PR DESCRIPTION
Now that the Seahorse preprint is public, cite the **paper** first and keep the software (Zenodo DOI) as the secondary entry.

- **README** + **docs/cite.md**: add the arXiv BibTeX (`Seahorse: A Unified Benchmarking Framework for Spatiotemporal Event Modeling`, cs.LG), drop the 'paper coming soon' note.
- **CITATION.cff**: fill the `preferred-citation` title + arXiv reference (closes the arXiv back-fill).

Metadata pulled from arXiv; strict build + CFF validation pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)